### PR TITLE
로컬 db 작업을 위한 Docker compose 작성 및 Spring datasource 설정

### DIFF
--- a/infra/mg_mysql-container/docker-compose.yml
+++ b/infra/mg_mysql-container/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.8'
+
+networks:
+  default:
+    name: myongji-graduate
+
+volumes:
+  data:
+    driver: local
+  config:
+    driver: local
+
+services:
+  db:
+    image: mysql:8.0.29
+    container_name: mg-mysql
+    ports:
+      - 33066:3306
+    volumes:
+      - data:/var/lib/mysql
+      - config:/etc/mysql/conf.d
+    environment:
+      MYSQL_ROOT_PASSWORD: mysql
+      MYSQL_DATABASE: myongji_graduate
+    platform: linux/x86_64
+    restart: always

--- a/infra/mg_mysql-container/remove.sh
+++ b/infra/mg_mysql-container/remove.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+docker rm mg-mysql
+docker rmi mysql:mysql:8.0.29
+
+docker volume rm mg_mysql-container_config
+docker volume rm mg_mysql-container_data

--- a/infra/mg_mysql-container/start.sh
+++ b/infra/mg_mysql-container/start.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+docker start mg-mysql

--- a/infra/mg_mysql-container/stop.sh
+++ b/infra/mg_mysql-container/stop.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+docker stop mg-mysql

--- a/infra/mysql.sh
+++ b/infra/mysql.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+docker-compose --file ./mg_mysql-container/docker-compose.yml up -d

--- a/infra/ps.sh
+++ b/infra/ps.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+docker ps --format "table {{.Names}}\t{{.Status}}"

--- a/infra/setup.sh
+++ b/infra/setup.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+docker network create myongji-graduate

--- a/infra/spring-boot.sh
+++ b/infra/spring-boot.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+docker-compose --file ./mysql_container/docker-compose.yml up -d

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,1 +1,8 @@
-
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:33066/myongji_graduate?serverTimezon=Asia/Seoul
+    username: root
+    password: mysql
+server:
+  port: 8088

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/MyongjiGraduateBeApplicationTests.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/MyongjiGraduateBeApplicationTests.java
@@ -2,7 +2,10 @@ package com.plzgraduate.myongjigraduatebe;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+
+@ActiveProfiles("test")
 @SpringBootTest
 class MyongjiGraduateBeApplicationTests {
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,4 @@
+spring:
+  datasource:
+    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+    url: jdbc:tc:mysql:8:///


### PR DESCRIPTION
## ✅ 작업 내용
- 로컬 db 작업을 위한 Docker compose 스크립트 작성
  - infra 폴더로 이동한 뒤 setup.sh 실행(1번만 하면 됨) 후 mysql.sh 실행하여 도커 확인
  아래와 같이 뜬다면 로컬 db 서버 띄우기 성공
  ![image](https://user-images.githubusercontent.com/61923768/192561822-6c70e003-461a-44aa-8748-2c6abed11c0d.png)
  - testContainer 적용 및 profile 적용 완료
    - 추후에 container 실행을 1번만 하게 하고, 설정 값을 클래스로 따로 받아서 하는 식으로 리팩토링 해야될 거 같습니다.

- Database 연결을 위한 Spring datasource 설정

## 🔗 링크 (Links)
- [이슈#4](#4)
