### PR TITLE
지원 학번 조회 기능 구현

### DIFF
--- a/src/main/java/com/plzgraduate/myongjigraduatebe/department/entity/Department.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/department/entity/Department.java
@@ -3,6 +3,7 @@ package com.plzgraduate.myongjigraduatebe.department.entity;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
 
 import com.plzgraduate.myongjigraduatebe.common.entity.BaseEntity;
 
@@ -15,11 +16,39 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Department extends BaseEntity {
 
+  public static final int DEFAULT_ENDED_ENTRY_YEAR = 99;
   @NotNull
   @Column()
   private String name;
 
-  public Department(String name) {
+  @NotNull
+  @Positive
+  @Column(columnDefinition = "UNSIGNED TINYINT", nullable = false)
+  private int startedEntryYear;
+
+  @NotNull
+  @Positive
+  @Column(columnDefinition = "UNSIGNED TINYINT")
+  private int endedEntryYear;
+
+  public Department(
+      String name,
+      int startedEntryYear
+  ) {
+    this(name, startedEntryYear, DEFAULT_ENDED_ENTRY_YEAR);
+  }
+
+  public Department(
+      String name,
+      int startedEntryYear,
+      int endedEntryYear
+  ) {
     this.name = name;
+    this.startedEntryYear = startedEntryYear;
+    this.endedEntryYear = endedEntryYear;
+  }
+
+  public boolean isSupported(int entryYear) {
+    return startedEntryYear <= entryYear && entryYear <= endedEntryYear;
   }
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/department/service/DefaultDepartmentService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/department/service/DefaultDepartmentService.java
@@ -2,6 +2,7 @@ package com.plzgraduate.myongjigraduatebe.department.service;
 
 import org.springframework.stereotype.Service;
 
+import com.plzgraduate.myongjigraduatebe.department.entity.Department;
 import com.plzgraduate.myongjigraduatebe.department.repository.DepartmentRepository;
 import com.plzgraduate.myongjigraduatebe.department.service.dto.AllDepartmentsResponse;
 
@@ -16,5 +17,17 @@ public class DefaultDepartmentService implements DepartmentService {
   @Override
   public AllDepartmentsResponse findAll() {
     return AllDepartmentsResponse.from(departmentRepository.findAll());
+  }
+
+  @Override
+  public boolean isSupportedEntryYear(
+      long id,
+      int entryYear
+  ) {
+    Department department = departmentRepository
+        .findById(id)
+        .orElseThrow(() -> new IllegalArgumentException("학과를 찾을 수 없습니다."));
+
+    return department.isSupported(entryYear);
   }
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/department/service/DepartmentService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/department/service/DepartmentService.java
@@ -5,4 +5,6 @@ import com.plzgraduate.myongjigraduatebe.department.service.dto.AllDepartmentsRe
 public interface DepartmentService {
 
   AllDepartmentsResponse findAll();
+
+  boolean isSupportedEntryYear(long id, int entryYear);
 }

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/department/controller/DepartmentApiControllerTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/department/controller/DepartmentApiControllerTest.java
@@ -35,8 +35,10 @@ class DepartmentApiControllerTest extends ControllerSetUp {
   private static final long departmentId1 = 1L;
   private static final long departmentId2 = 2L;
 
-  private static final Department department1 = new Department("test1");
-  private static final Department department2 = new Department("test2");
+  private static final int startedEntryYear = 15;
+
+  private static final Department department1 = new Department("test1", startedEntryYear);
+  private static final Department department2 = new Department("test2", startedEntryYear);
 
   private static AllDepartmentsResponse allDepartmentsResponse;
 

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/department/service/DefaultDepartmentServiceTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/department/service/DefaultDepartmentServiceTest.java
@@ -5,12 +5,15 @@ import static org.mockito.BDDMockito.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -33,8 +36,12 @@ class DefaultDepartmentServiceTest {
   private static final long departmentId1 = 1L;
   private static final long departmentId2 = 2L;
 
-  private static final Department department1 = new Department("test1");
-  private static final Department department2 = new Department("test2");
+  private static final int startedEntryYear = 15;
+
+  private static final int endedEntryYear = 20;
+
+  private static final Department department1 = new Department("test1", startedEntryYear, endedEntryYear);
+  private static final Department department2 = new Department("test2", startedEntryYear, endedEntryYear);
 
   private static final List<Department> departments = new ArrayList<>(2);
 
@@ -75,6 +82,74 @@ class DefaultDepartmentServiceTest {
             .toArray();
 
         assertThat(responseIds).isEqualTo(departmentsIds);
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("isSupportedEntryYear 메소드는")
+  class DescribeIsSupportedEntryYear {
+
+    @Nested
+    @DisplayName("학과 id에 해당하는 데이터가 없다면")
+    class ContextWithNotExistsDepartmentId {
+
+      @Test
+      @DisplayName("예외를 발생시킨다.")
+      void ItThrowsIllegalArgumentsException() {
+        // given
+        long departmentId = Long.MAX_VALUE - departmentId1;
+        int entryYear = 19;
+        given(departmentRepository.findById(departmentId)).willReturn(Optional.empty());
+
+        // when
+        // then
+        assertThatThrownBy(() -> departmentService.isSupportedEntryYear(
+            departmentId,
+            entryYear
+        )).isInstanceOf(IllegalArgumentException.class);
+      }
+    }
+
+    @Nested
+    @DisplayName("해당 학번을 지원하지 않는다면")
+    class ContextWithNotSupportedEntryYear {
+
+      @ParameterizedTest
+      @ValueSource(ints = {startedEntryYear - 1, endedEntryYear + 1})
+      @DisplayName("false를 반환합니다.")
+      void ItReturnFalse(int entryYear) {
+        // given
+        given(departmentRepository.findById(departmentId1)).willReturn(Optional.of(department1));
+
+        // when
+        boolean response = departmentService.isSupportedEntryYear(
+            departmentId1,
+            entryYear
+        );
+        // then
+        assertThat(response).isFalse();
+      }
+    }
+
+    @Nested
+    @DisplayName("해당 학번을 지원한다면")
+    class ContextWithSupportedEntryYear {
+
+      @ParameterizedTest
+      @ValueSource(ints = {startedEntryYear, endedEntryYear, (startedEntryYear + endedEntryYear) / 2})
+      @DisplayName("true를 반환합니다.")
+      void ItReturnTrue(int entryYear) {
+        // given
+        given(departmentRepository.findById(departmentId1)).willReturn(Optional.of(department1));
+
+        // when
+        boolean response = departmentService.isSupportedEntryYear(
+            departmentId1,
+            entryYear
+        );
+        // then
+        assertThat(response).isTrue();
       }
     }
   }


### PR DESCRIPTION
## ✅ 작업 내용
- 학과 엔티티에 지원 학번 정보 추가
- 지원 학번 조회 기능 구현
- 지원 학번 조회 기능 테스트 작성

## 🤔 고민 했던 부분
- 지원 학번은 학과마다 다를 수 있다?
  - 학과가 통폐합되거나 새로 생긴다면 서비스에서 지원하는 학번은 학과마다 다를 수 있음
  - 학과에 의존적인 정보라고 판단하여 엔티티에 정보 넣는 것으로 판단
- 지원 학번 조회 기능에서 학과에 대한 정보는 어떤 것을 받을 까?
  - 프론트 혹은 서버 내부적으로 학과에 대한 정보를 id 혹은 name으로 가지고 다닐 것으로 예상! 둘 다 중복은 없겠지만 기본키 인덱스를 활용하기 위해 id값으로 인자 선정
  - 입력된 학번 정보를 실제로 지원하는 지는 `묻지 말고 시켜라!`를 이용하여 학과 도메인(엔티티)에게 함수를 추가하여 구현

## 🔗 링크 (Links)
- #13 
