### PR TITLE
수강과목정보 중 사용하지 않는 데이터 처리 중단

### DIFF
--- a/src/main/java/com/plzgraduate/myongjigraduatebe/common/utils/PdfParser.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/common/utils/PdfParser.java
@@ -19,10 +19,17 @@ public class PdfParser {
                                                                           .getInputStream());
     com.aspose.pdf.TableAbsorber absorber = new com.aspose.pdf.TableAbsorber();
     StringBuilder sb = new StringBuilder();
+    int blankedIdx = 0;
     for (com.aspose.pdf.Page page : pdfDocument.getPages()) {
       absorber.visit(page);
       for (com.aspose.pdf.AbsorbedTable table : absorber.getTableList()) {
         for (com.aspose.pdf.AbsorbedRow row : table.getRowList()) {
+          if(row.getCellList().size() == 1 && blankedIdx>5){
+            return sb.toString();
+          }
+          if(row.getCellList().size() == 1 && blankedIdx<=5){
+            blankedIdx++;
+          }
           for (com.aspose.pdf.AbsorbedCell cell : row.getCellList()) {
             for (com.aspose.pdf.TextFragment fragment : cell.getTextFragments()) {
               for (com.aspose.pdf.TextSegment seg : fragment.getSegments()) {


### PR DESCRIPTION
## ✅ 작업 내용
- pdf 파일 중 공백이 있을 경우에 에러를 해결할수 있도록 리팩토링 하였습니다.
## 🤔 고민 했던 부분
파싱 로직을 수정할지 텍스트를 변환하는 로직을 수정할지 고민을 했었지만 파싱 자체를 하지 않는것으로 했습니다.
