### PR TITLE
User 엔티티 객체 관련 테스트 코드 작성

### DIFF
--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/entity/StudentNumber.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/entity/StudentNumber.java
@@ -1,6 +1,7 @@
 package com.plzgraduate.myongjigraduatebe.user.entity;
 
 import java.util.Objects;
+import java.util.regex.Pattern;
 
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -11,6 +12,7 @@ import lombok.NoArgsConstructor;
 public class StudentNumber {
 
   private static final int LENGTH = 8;
+  private static final String REG = "^[0-9]{" + LENGTH + "}";
 
   private String value;
 
@@ -24,11 +26,10 @@ public class StudentNumber {
   }
 
   private static void validate(String value) {
-    if (value.length() != LENGTH) {
-      throw new IllegalArgumentException("학번의 길이 값이 올바르지 않습니다.");
+    if (value == null || !Pattern.matches(REG, value)) {
+      throw new IllegalArgumentException("학번이 올바르지 않습니다.");
     }
   }
-
 
   @Override
   public boolean equals(Object o) {

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/user/entity/EntryYearTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/user/entity/EntryYearTest.java
@@ -59,7 +59,7 @@ class EntryYearTest {
 
       @ParameterizedTest
       @ArgumentsSource(ValidValueArgumentsProvider.class)
-      @DisplayName("객체를 qksghks한다.")
+      @DisplayName("객체를 생성한다.")
       void ItReturnInstance(int value) {
         // given
         // when

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/user/entity/EntryYearTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/user/entity/EntryYearTest.java
@@ -1,0 +1,138 @@
+package com.plzgraduate.myongjigraduatebe.user.entity;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.lang.reflect.Field;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+class EntryYearTest {
+
+  private static final int MIN_VALUE;
+  private static final int MAX_VALUE;
+
+  static {
+    try {
+      Field minValueField = EntryYear.class.getDeclaredField("MIN_VALUE");
+      minValueField.setAccessible(true);
+      MIN_VALUE = minValueField.getInt(null);
+      Field maxValueField = EntryYear.class.getDeclaredField("MAX_VALUE");
+      maxValueField.setAccessible(true);
+      MAX_VALUE = maxValueField.getInt(null);
+    } catch (IllegalAccessException | NoSuchFieldException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Nested
+  @DisplayName("of 메소드는")
+  class DescribeOfMethod {
+
+    @Nested
+    @DisplayName("범위 밖에 인트 값에 대해서")
+    class ContextOutOfRange {
+
+      @ParameterizedTest
+      @ArgumentsSource(OutOfRangeValueArgumentsProvider.class)
+      @DisplayName("예외를 던진다")
+      void ItThrowsIllegalArgumentException(int value) {
+        // given
+        // when
+        // then
+        assertThatThrownBy(() -> EntryYear.of(value))
+            .isInstanceOf(IllegalArgumentException.class);
+
+      }
+    }
+
+    @Nested
+    @DisplayName("범위 내 값에 대해서는")
+    class ContextValidValue {
+
+      @ParameterizedTest
+      @ArgumentsSource(ValidValueArgumentsProvider.class)
+      @DisplayName("객체를 qksghks한다.")
+      void ItReturnInstance(int value) {
+        // given
+        // when
+        EntryYear entryYear = EntryYear.of(value);
+
+        // then
+        assertThat(entryYear).isNotNull();
+      }
+    }
+  }
+  @Nested
+  @DisplayName("equals 메소드는")
+  class DescribeEqualsMethod {
+
+    @Nested
+    @DisplayName("같은 value로 만들어진 객체는")
+    class ContextInstanceFromSameValue {
+
+      @ParameterizedTest
+      @ArgumentsSource(ValidValueArgumentsProvider.class)
+      @DisplayName("true를 반환한다")
+      void ItReturnTrue(int value) {
+        // given
+        // when
+        EntryYear entryYear1 = EntryYear.of(value);
+        EntryYear entryYear2 = EntryYear.of(value);
+
+        // then
+        assertThat(entryYear1.equals(entryYear2)).isTrue();
+      }
+    }
+
+    @Nested
+    @DisplayName("서로 다른 value로 만들어진 객체는")
+    class ContextInstanceFromDifferenceValue {
+
+      @Test
+      @DisplayName("false를 반환한다")
+      void ItReturnFalse() {
+        // given
+        // when
+        EntryYear entryYear1 = EntryYear.of(MIN_VALUE);
+        EntryYear entryYear2 = EntryYear.of(MAX_VALUE);
+
+        // then
+        assertThat(entryYear1.equals(entryYear2)).isFalse();
+      }
+    }
+  }
+
+  static class OutOfRangeValueArgumentsProvider implements ArgumentsProvider {
+
+    @Override
+    public Stream<Arguments> provideArguments(ExtensionContext context) {
+      return Stream.of(
+          Arguments.of(Integer.MIN_VALUE),
+          Arguments.of(MIN_VALUE - 1),
+          Arguments.of(MAX_VALUE + 1),
+          Arguments.of(Integer.MAX_VALUE)
+      );
+    }
+  }
+
+  static class ValidValueArgumentsProvider implements ArgumentsProvider {
+
+    @Override
+    public Stream<Arguments> provideArguments(ExtensionContext context) {
+      return Stream.of(
+          Arguments.of(MIN_VALUE),
+          Arguments.of(MAX_VALUE),
+          Arguments.of((MIN_VALUE + MAX_VALUE) / 2)
+      );
+    }
+  }
+
+}

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/user/entity/StudentNumberTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/user/entity/StudentNumberTest.java
@@ -55,7 +55,7 @@ class StudentNumberTest {
 
       @ParameterizedTest
       @ValueSource(strings = {"60191667", "12345678"})
-      @DisplayName("객체를 생선한다.")
+      @DisplayName("객체를 생성한다.")
       void ItReturnInstance(String value) {
         // given
         // when

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/user/entity/StudentNumberTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/user/entity/StudentNumberTest.java
@@ -1,0 +1,110 @@
+package com.plzgraduate.myongjigraduatebe.user.entity;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class StudentNumberTest {
+
+  @Nested
+  @DisplayName("of 메소드는")
+  class DescribeOfMethod {
+
+    @Nested
+    @DisplayName("길이가 8이 아닌 문자열은")
+    class ContextNotValidLength {
+
+      @ParameterizedTest
+      @ValueSource(strings = {"1234567", "숫자가아닌것들"})
+      @NullAndEmptySource()
+      @DisplayName("예외를 던진다")
+      void ItThrowsIllegalArgumentException(String value) {
+        // given
+        // when
+        // then
+        assertThatThrownBy(() -> StudentNumber.of(value))
+            .isInstanceOf(IllegalArgumentException.class);
+
+      }
+    }
+
+    @Nested
+    @DisplayName("길이가 8이지만 숫자가 아닌 문자열은")
+    class ContextNotNumberStringWithValidLength {
+
+      @ParameterizedTest
+      @ValueSource(strings = {"영일이삼사오육칠팔"})
+      @DisplayName("예외를 던진다.")
+      void ItReturnInstance(String value) {
+        // given
+        // when
+        // then
+        assertThatThrownBy(() -> StudentNumber.of(value))
+            .isInstanceOf(IllegalArgumentException.class);
+      }
+    }
+
+    @Nested
+    @DisplayName("8자리 숫자로된 문자열은")
+    class ContextNumberStringWithValidLength {
+
+      @ParameterizedTest
+      @ValueSource(strings = {"60191667", "12345678"})
+      @DisplayName("객체를 생선한다.")
+      void ItReturnInstance(String value) {
+        // given
+        // when
+        StudentNumber studentNumber = StudentNumber.of(value);
+
+        // then
+        assertThat(studentNumber).isNotNull();
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("equals 메소드는")
+  class DescribeEqualsMethod {
+
+    @Nested
+    @DisplayName("같은 value로 만들어진 객체는")
+    class ContextInstanceFromSameValue {
+
+      @ParameterizedTest
+      @ValueSource(strings = {"60191667", "12345678"})
+      @DisplayName("true를 반환한다")
+      void ItReturnTrue(String value) {
+        // given
+        // when
+        StudentNumber studentNumber1 = StudentNumber.of(value);
+        StudentNumber studentNumber2 = StudentNumber.of(value);
+
+        // then
+        assertThat(studentNumber1.equals(studentNumber2)).isTrue();
+      }
+    }
+
+    @Nested
+    @DisplayName("서로 다른 value로 만들어진 객체는")
+    class ContextInstanceFromDifferenceValue {
+
+      @Test
+      @DisplayName("false를 반환한다")
+      void ItReturnFalse() {
+        // given
+        // when
+        StudentNumber studentNumber1 = StudentNumber.of("60191667");
+        StudentNumber studentNumber2 = StudentNumber.of("12345678");
+
+        // then
+        assertThat(studentNumber1.equals(studentNumber2)).isFalse();
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
## ✅ 작업 내용
- User 엔티티에 사용되는 `EntryYear` VO와 `StudentNumber` VO의 테스트 작성

## 🤔 고민 했던 부분
- StudentNumber 검증 코드가 기존에는 8자리 길이만 확인하였습니다.
- 여기에 숫자로 구성된 문자열인지 확인하는 로직을 추가하였습니다.
- 검증 방식을 정규 표현식을 활용하는 방법으로 바꾸었습니다.
