### PR TITLE
수강 과목 저장

### DIFF
--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/controller/UserController.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/controller/UserController.java
@@ -1,0 +1,34 @@
+package com.plzgraduate.myongjigraduatebe.user.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.plzgraduate.myongjigraduatebe.user.service.TakenLectureService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1/user")
+public class UserController {
+
+  private final TakenLectureService takenLectureService;
+
+  @PostMapping("/{id}/taken-lecture")
+  @ResponseStatus(HttpStatus.OK)
+  public String save(
+      @PathVariable("id") Long userId,
+      @RequestBody String parsingText
+  ) {
+    String[] userText = parsingText.split(", ");
+    String[] lectureText = parsingText.split(", ")[27].split(",");
+    takenLectureService.saveTakenLecture(userId, lectureText);
+    return "redirect:/{id}/taken-lecture";
+  }
+
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/entity/TakenLecture.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/entity/TakenLecture.java
@@ -26,4 +26,11 @@ public class TakenLecture extends BaseEntity {
   @JoinColumn(foreignKey = @ForeignKey(name = "FK_LECTURE_TAKEN_LECTURE"))
   private Lecture lecture;
 
+  public TakenLecture(
+      User user,
+      Lecture lecture
+  ) {
+    this.user = user;
+    this.lecture = lecture;
+  }
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/repository/TakenLectureRepository.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/repository/TakenLectureRepository.java
@@ -1,0 +1,8 @@
+package com.plzgraduate.myongjigraduatebe.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.plzgraduate.myongjigraduatebe.user.entity.TakenLecture;
+
+public interface TakenLectureRepository extends JpaRepository<TakenLecture, Long> {
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/repository/UserRepository.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package com.plzgraduate.myongjigraduatebe.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.plzgraduate.myongjigraduatebe.user.entity.User;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+  User findUserById(Long id);
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/service/DefaultTakenLectureService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/service/DefaultTakenLectureService.java
@@ -1,0 +1,51 @@
+package com.plzgraduate.myongjigraduatebe.user.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.plzgraduate.myongjigraduatebe.lecture.entity.Lecture;
+import com.plzgraduate.myongjigraduatebe.lecture.entity.LectureCode;
+import com.plzgraduate.myongjigraduatebe.lecture.repository.LectureRepository;
+import com.plzgraduate.myongjigraduatebe.user.entity.TakenLecture;
+import com.plzgraduate.myongjigraduatebe.user.entity.User;
+import com.plzgraduate.myongjigraduatebe.user.repository.TakenLectureRepository;
+import com.plzgraduate.myongjigraduatebe.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class DefaultTakenLectureService implements TakenLectureService {
+  private final LectureRepository lectureRepository;
+  private final TakenLectureRepository takenLectureRepository;
+  private final UserRepository userRepository;
+
+  @Override
+  public void saveTakenLecture(
+      Long userId,
+      String[] lectureText
+  ) {
+    User user = userRepository.findUserById(userId);
+    List<LectureCode> takenLectureCodes = getTakenLectureCodes(lectureText);
+    List<Lecture> lectures = lectureRepository.findAllByLectureCodeIsIn(takenLectureCodes);
+    lectures.forEach(lecture -> takenLectureRepository.save(new TakenLecture(user, lecture)));
+  }
+
+  private List<LectureCode> getTakenLectureCodes(
+      String[] splitText
+  ) {
+    int countTakenLecture = (splitText.length - 9) / 8;
+    List<LectureCode> takenLectureCods = new ArrayList<>(countTakenLecture);
+    for (int i = 9; i < splitText.length; i += 7) {
+      String code = splitText[i + 3];
+      if (i + 7 < splitText.length && !splitText[i + 7].isBlank() && Character.isDigit(splitText[i + 7].charAt(0))) {
+        i++;
+      }
+      takenLectureCods.add(LectureCode.of(code));
+    }
+    return takenLectureCods;
+  }
+
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/service/TakenLectureService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/service/TakenLectureService.java
@@ -1,0 +1,8 @@
+package com.plzgraduate.myongjigraduatebe.user.service;
+
+public interface TakenLectureService {
+  void saveTakenLecture(
+      Long userId,
+      String[] lectureText
+  );
+}


### PR DESCRIPTION
## ✅ 작업 내용
- 파싱데이터를 변환해 수강과목 엔티티에 저장하는 기능입니다.

## 🔗 링크 (Links)
- [이슈](#)
- [API 스펙 문서](#)
- [기획 문서](#)
