### PR TITLE
영어 레벨 표기 및 전달 방식 수정

### DIFF
--- a/src/main/java/com/plzgraduate/myongjigraduatebe/auth/dto/SignUpRequest.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/auth/dto/SignUpRequest.java
@@ -29,12 +29,12 @@ public class SignUpRequest {
       @JsonProperty("studentNumber")
       StudentNumber studentNumber,
       @JsonProperty("engLv")
-      EnglishLevel engLv
+      String engLv
   ) {
     this.userId = userId;
     this.password = password;
     this.studentNumber = studentNumber;
-    this.engLv = engLv;
+    this.engLv = EnglishLevel.valueOf(engLv);
   }
 
   public User toEntity(PasswordEncoder passwordEncoder) {

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/entity/EnglishLevel.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/entity/EnglishLevel.java
@@ -1,33 +1,7 @@
 package com.plzgraduate.myongjigraduatebe.user.entity;
 
-import java.util.List;
-
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.plzgraduate.myongjigraduatebe.lecture.entity.LectureCode;
-
-import lombok.Getter;
-
-@Getter
 public enum EnglishLevel {
-
-  LOW(List.of(LectureCode.of("KMA02106"), LectureCode.of("KMA02107"), LectureCode.of("KMA02108"), LectureCode.of("KMA02109"))),
-  MIDDLE(List.of(LectureCode.of("KMA02123"), LectureCode.of("KMA02124"), LectureCode.of("KMA02125"), LectureCode.of("KMA02126"))),
-  HIGH(List.of());
-
-  private final List<LectureCode> lectureCodeList;
-
-  EnglishLevel(List<LectureCode> lectureCodeList) {
-    this.lectureCodeList = lectureCodeList;
-  }
-
-  @JsonCreator
-  public static EnglishLevel of(int ordinal) {
-    for (EnglishLevel engLv : values()) {
-      if (engLv.ordinal() == ordinal) {
-        return engLv;
-      }
-    }
-
-    throw new IllegalArgumentException("영어 레벨을 확인해주세요");
-  }
+  ENG12,
+  ENG34,
+  FREE
 }

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/common/MockUserIsInitializedSecurityContextFactory.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/common/MockUserIsInitializedSecurityContextFactory.java
@@ -24,7 +24,7 @@ public class MockUserIsInitializedSecurityContextFactory implements WithSecurity
     final UserId userId = UserId.valueOf("testUser");
     final String password = "testUserPassword";
     final StudentNumber studentNumber = StudentNumber.valueOf("12345678");
-    final EnglishLevel engLv = EnglishLevel.MIDDLE;
+    final EnglishLevel engLv = EnglishLevel.ENG34;
 
     User user = new User(userId, password, studentNumber, engLv);
 

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/common/MockUserNotIsInitializedSecurityContextFactory.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/common/MockUserNotIsInitializedSecurityContextFactory.java
@@ -23,7 +23,7 @@ public class MockUserNotIsInitializedSecurityContextFactory implements WithSecur
     final UserId userId = UserId.valueOf("testUser");
     final String password = "testUserPassword";
     final StudentNumber studentNumber = StudentNumber.valueOf("12345678");
-    final EnglishLevel engLv = EnglishLevel.MIDDLE;
+    final EnglishLevel engLv = EnglishLevel.ENG34;
 
     User user = new User(userId, password, studentNumber, engLv);
 

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/user/controller/UserControllerTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/user/controller/UserControllerTest.java
@@ -55,7 +55,7 @@ class UserControllerTest extends ControllerSetUp {
   private static final String userId = "userId";
   private static final String password = "testpassword";
   private static final String studentNumber = "60191667";
-  private static final EnglishLevel engLv = EnglishLevel.MIDDLE;
+  private static final EnglishLevel engLv = EnglishLevel.ENG34;
   private static final User user = new User(UserId.valueOf(userId), password, StudentNumber.valueOf(studentNumber), engLv);
 
   @BeforeAll

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/user/service/DefaultUserServiceTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/user/service/DefaultUserServiceTest.java
@@ -39,7 +39,7 @@ class DefaultUserServiceTest {
   private static final String userId = "userId";
   private static final String password = "testpassword";
   private static final String studentNumber = "60191667";
-  private static final EnglishLevel engLv = EnglishLevel.MIDDLE;
+  private static final EnglishLevel engLv = EnglishLevel.ENG34;
   private static final User user = new User(UserId.valueOf(userId), password, StudentNumber.valueOf(studentNumber), engLv);
 
   @BeforeAll


### PR DESCRIPTION
## ✅ 작업 내용
- 영어레벨 표기를 직관적으로 변경
- 영어레벨 전달 방식으로 Ordinal -> name으로 변경

## 🔗 링크 (Links)
- close #103 