### PR TITLE
학사정보 조회 - 과목

### DIFF
--- a/src/main/java/com/plzgraduate/myongjigraduatebe/common/config/SecurityConfig.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/common/config/SecurityConfig.java
@@ -41,7 +41,8 @@ public class SecurityConfig {
             API_V1_PREFIX + "/users/by/student-number/**", // 유저아이디 찾기
             API_V1_PREFIX + "/users/reset-pw", // 비밀번호 재설정
             API_V1_PREFIX + "/users/me/init",  // 토큰 유효성 및 유저 초기화 체크
-            API_V1_PREFIX + "/bachelor-info/requirement" //학사정보-졸업요건학점 조회
+            API_V1_PREFIX + "/bachelor-info/requirement", //학사정보-졸업요건학점 조회
+            API_V1_PREFIX + "/bachelor-info/lectures" //학사정보 - 졸업과목 조회
         )
         .permitAll()
         .anyRequest()

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/controller/GraduationRequirementApiController.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/controller/GraduationRequirementApiController.java
@@ -1,5 +1,6 @@
 package com.plzgraduate.myongjigraduatebe.graduation.controller;
 
+import com.plzgraduate.myongjigraduatebe.graduation.dto.BachelorInfoLecturesResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -27,5 +28,14 @@ public class GraduationRequirementApiController {
       BachelorInfoRequest bachelorInfoRequest
   ) {
     return graduationRequirementService.getBachelorInfoRequirement(bachelorInfoRequest);
+  }
+
+  @GetMapping("/lectures")
+  @ResponseStatus(HttpStatus.OK)
+  public BachelorInfoLecturesResponse getBachelorInfoLectures(
+          @RequestBody
+          BachelorInfoRequest bachelorInfoRequest
+  ){
+    return graduationRequirementService.getBachelorInfoLectures(bachelorInfoRequest);
   }
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/dto/BachelorInfoCategory.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/dto/BachelorInfoCategory.java
@@ -1,0 +1,18 @@
+package com.plzgraduate.myongjigraduatebe.graduation.dto;
+
+import com.plzgraduate.myongjigraduatebe.lecture.dto.LectureResponse;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+public class BachelorInfoCategory {
+    private String categoryName;
+    private List<LectureResponse> lectures;
+
+    public static BachelorInfoCategory of(String categoryName, List<LectureResponse> lectures) {
+        return new BachelorInfoCategory(categoryName, lectures);
+    }
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/dto/BachelorInfoLecturesResponse.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/dto/BachelorInfoLecturesResponse.java
@@ -1,0 +1,30 @@
+package com.plzgraduate.myongjigraduatebe.graduation.dto;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+public class BachelorInfoLecturesResponse {
+
+    private List<BachelorInfoCategory> major;
+    private List<BachelorInfoCategory> commonCulture;
+    private List<BachelorInfoCategory> coreCulture;
+    private List<BachelorInfoCategory> basicAcademicalCulture;
+
+    public static BachelorInfoLecturesResponse of(
+            List<BachelorInfoCategory> major,
+            List<BachelorInfoCategory> commonCulture,
+            List<BachelorInfoCategory> coreCulture,
+            List<BachelorInfoCategory> basicAcademicalCulture){
+        return BachelorInfoLecturesResponse.builder()
+                .major(major)
+                .commonCulture(commonCulture)
+                .coreCulture(coreCulture)
+                .basicAcademicalCulture(basicAcademicalCulture)
+                .build();
+    }
+
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/service/GraduationRequirementService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/service/GraduationRequirementService.java
@@ -1,9 +1,12 @@
 package com.plzgraduate.myongjigraduatebe.graduation.service;
 
+import com.plzgraduate.myongjigraduatebe.graduation.dto.BachelorInfoLecturesResponse;
 import com.plzgraduate.myongjigraduatebe.graduation.dto.BachelorInfoRequest;
 import com.plzgraduate.myongjigraduatebe.graduation.dto.BachelorInfoRequirementResponse;
 
 public interface GraduationRequirementService {
 
   BachelorInfoRequirementResponse getBachelorInfoRequirement(BachelorInfoRequest bachelorInfoRequest);
+
+  BachelorInfoLecturesResponse getBachelorInfoLectures(BachelorInfoRequest bachelorInfoRequest);
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/service/GraduationRequirementServiceImpl.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/service/GraduationRequirementServiceImpl.java
@@ -146,12 +146,11 @@ public class GraduationRequirementServiceImpl implements GraduationRequirementSe
   }
 
   private void addEnglishLevelOverThreeToCommonCultureMap(Map<String, List<LectureResponse>> commonCultureMap) {
-    List<String> englishThreeFourCode = new ArrayList<>(){{
-      add("KMA02123");
-      add("KMA02124");
-      add("KMA02125");
-      add("KMA02126");
-    }};
+    List<String> englishThreeFourCode = new ArrayList<>(){};
+    englishThreeFourCode.add("KMA02123");
+    englishThreeFourCode.add("KMA02124");
+    englishThreeFourCode.add("KMA02125");
+    englishThreeFourCode.add("KMA02126");
 
     englishThreeFourCode.forEach( lectureCode -> {
       Optional<Lecture> byLectureCode = lectureRepository.findByLectureCode(LectureCode.of(lectureCode));

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/service/GraduationRequirementServiceImpl.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/service/GraduationRequirementServiceImpl.java
@@ -102,6 +102,9 @@ public class GraduationRequirementServiceImpl implements GraduationRequirementSe
             divideMajorByMandatory(majorMap, graduationLecture, lectureCategory, lecture);
             break;
           case "COMMON_CULTURE":
+            if(lecture.getLectureCode().getCode().equals("KMA00101") && graduationLecture.isMandatory()){
+              lecture.setName(lecture.getName() + "(필수)");
+            }
             commonCultureMap.computeIfAbsent(lectureCategory.getDetailCategory(), k -> new ArrayList<>())
                     .add(LectureResponse.from(lecture));
             break;

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/service/GraduationRequirementServiceImpl.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/service/GraduationRequirementServiceImpl.java
@@ -1,5 +1,19 @@
 package com.plzgraduate.myongjigraduatebe.graduation.service;
 
+import com.plzgraduate.myongjigraduatebe.department.entity.Department;
+import com.plzgraduate.myongjigraduatebe.department.repository.DepartmentRepository;
+import com.plzgraduate.myongjigraduatebe.graduation.dto.BachelorInfoCategory;
+import com.plzgraduate.myongjigraduatebe.graduation.dto.BachelorInfoLecturesResponse;
+import com.plzgraduate.myongjigraduatebe.graduation.entity.GraduationLecture;
+import com.plzgraduate.myongjigraduatebe.graduation.entity.LectureCategory;
+import com.plzgraduate.myongjigraduatebe.graduation.repository.GraduationLectureRepository;
+import com.plzgraduate.myongjigraduatebe.lecture.dto.LectureResponse;
+import com.plzgraduate.myongjigraduatebe.lecture.entity.Lecture;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +33,8 @@ public class GraduationRequirementServiceImpl implements GraduationRequirementSe
   private static final EnglishLevel DEFAULT_ENGLISH_LV = EnglishLevel.ENG12;
 
   private final GraduationRequirementRepository graduationRequirementRepository;
+  private final GraduationLectureRepository graduationLectureRepository;
+  private final DepartmentRepository departmentRepository;
 
   @Override
   public BachelorInfoRequirementResponse getBachelorInfoRequirement(BachelorInfoRequest bachelorInfoRequest) {
@@ -28,5 +44,85 @@ public class GraduationRequirementServiceImpl implements GraduationRequirementSe
         DEFAULT_ENGLISH_LV
     );
     return BachelorInfoRequirementResponse.from(foundGraduationRequirement);
+  }
+
+  @Override
+  public BachelorInfoLecturesResponse getBachelorInfoLectures(BachelorInfoRequest bachelorInfoRequest) {
+    Optional<Department> byName = departmentRepository.findByName(bachelorInfoRequest.getDepartment());
+    if (byName.isEmpty()) {
+      throw new IllegalArgumentException("해당 학과가 존재하지 않습니다.");
+    }
+    List<GraduationLecture> graduationLectures = graduationLectureRepository.findAllByDepartmentAndEntryYearWithFetchJoin(
+            byName.get(),
+            bachelorInfoRequest.getEntryYear(),
+            DEFAULT_ENGLISH_LV
+    );
+
+    Map<String, List<LectureResponse>> majorMap = new HashMap<>(){{
+      put("전공필수", new ArrayList<>());
+      put("전공선택", new ArrayList<>());
+    }};
+    Map<String, List<LectureResponse>> commonCultureMap = new HashMap<>();
+    Map<String, List<LectureResponse>> coreCultureMap = new HashMap<>();
+    Map<String, List<LectureResponse>> basicAcademicalCultureMap = new HashMap<>(){{
+      put("학문기초교양", new ArrayList<>());
+    }};
+
+    classifyGraduationLectures(graduationLectures, majorMap, commonCultureMap, coreCultureMap, basicAcademicalCultureMap);
+
+    return BachelorInfoLecturesResponse.of(
+            createBachelorInfoCategory(majorMap),
+            createBachelorInfoCategory(commonCultureMap),
+            createBachelorInfoCategory(coreCultureMap),
+            createBachelorInfoCategory(basicAcademicalCultureMap)
+    );
+  }
+
+  private List<BachelorInfoCategory> createBachelorInfoCategory(Map<String, List<LectureResponse>> map) {
+    List<BachelorInfoCategory> bachelorInfoCategoryList = new ArrayList<>();
+    for( Map.Entry<String, List<LectureResponse>> entry: map.entrySet()) {
+      bachelorInfoCategoryList.add(BachelorInfoCategory.of(entry.getKey(), entry.getValue()));
+    }
+    return bachelorInfoCategoryList;
+  }
+
+  private void classifyGraduationLectures(List<GraduationLecture> graduationLectures,
+                                Map<String, List<LectureResponse>> majorMap,
+                                Map<String, List<LectureResponse>> commonCultureMap,
+                                Map<String, List<LectureResponse>> coreCultureMap,
+                                Map<String, List<LectureResponse>> basicAcademicalCultureMap) {
+
+    graduationLectures.forEach(graduationLecture -> {
+      LectureCategory lectureCategory = graduationLecture
+              .getLectureCategory();
+      Lecture lecture = graduationLecture.getLecture();
+      if(!lecture.isRevoked()){
+        switch (lectureCategory.getCategory().name()) {
+          case "MAJOR":
+            divideMajorByMandatory(majorMap, graduationLecture, lecture);
+            break;
+          case "COMMON_CULTURE":
+            commonCultureMap.computeIfAbsent(lectureCategory.getDetailCategory(), k -> new ArrayList<>())
+                    .add(LectureResponse.from(lecture));
+            break;
+          case "CORE_CULTURE":
+            coreCultureMap.computeIfAbsent(lectureCategory.getDetailCategory(), k -> new ArrayList<>())
+                    .add(LectureResponse.from(lecture));
+            break;
+          case "BASIC_ACADEMICAL_CULTURE":
+            basicAcademicalCultureMap.get("학문기초교양").add(LectureResponse.from(lecture));
+        }
+      }
+    });
+  }
+
+  private void divideMajorByMandatory(Map<String, List<LectureResponse>> majorMap, GraduationLecture graduationLecture,
+                                Lecture lecture) {
+    if(graduationLecture.isMandatory()){
+      majorMap.get("전공필수").add(LectureResponse.from(lecture));
+    }
+    else{
+      majorMap.get("전공선택").add(LectureResponse.from(lecture));
+    }
   }
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/service/GraduationRequirementServiceImpl.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/service/GraduationRequirementServiceImpl.java
@@ -9,6 +9,8 @@ import com.plzgraduate.myongjigraduatebe.graduation.entity.LectureCategory;
 import com.plzgraduate.myongjigraduatebe.graduation.repository.GraduationLectureRepository;
 import com.plzgraduate.myongjigraduatebe.lecture.dto.LectureResponse;
 import com.plzgraduate.myongjigraduatebe.lecture.entity.Lecture;
+import com.plzgraduate.myongjigraduatebe.lecture.entity.LectureCode;
+import com.plzgraduate.myongjigraduatebe.lecture.repository.LectureRepository;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -35,6 +37,7 @@ public class GraduationRequirementServiceImpl implements GraduationRequirementSe
   private final GraduationRequirementRepository graduationRequirementRepository;
   private final GraduationLectureRepository graduationLectureRepository;
   private final DepartmentRepository departmentRepository;
+  private final LectureRepository lectureRepository;
 
   @Override
   public BachelorInfoRequirementResponse getBachelorInfoRequirement(BachelorInfoRequest bachelorInfoRequest) {
@@ -69,6 +72,9 @@ public class GraduationRequirementServiceImpl implements GraduationRequirementSe
     }};
 
     classifyGraduationLectures(graduationLectures, majorMap, commonCultureMap, coreCultureMap, basicAcademicalCultureMap);
+
+    addChapelToCommonCultureMap(commonCultureMap);
+    addEnglishLevelOverThreeToCommonCultureMap(commonCultureMap);
 
     return BachelorInfoLecturesResponse.of(
             createBachelorInfoCategory(majorMap),
@@ -132,5 +138,27 @@ public class GraduationRequirementServiceImpl implements GraduationRequirementSe
       }
       majorMap.get("전공선택").add(LectureResponse.from(lecture));
     }
+  }
+
+  private void addChapelToCommonCultureMap(Map<String, List<LectureResponse>> commonCultureMap) {
+    Optional<Lecture> byLectureCode = lectureRepository.findByLectureCode(LectureCode.of("KMA02101"));
+    byLectureCode.ifPresent(lecture -> {
+      lecture.setName(lecture.getName() + ("(4회 필수 이수)"));
+      commonCultureMap.get("CHRISTIAN").add(LectureResponse.from(lecture));
+    });
+  }
+
+  private void addEnglishLevelOverThreeToCommonCultureMap(Map<String, List<LectureResponse>> commonCultureMap) {
+    List<String> englishThreeFourCode = new ArrayList<>(){{
+      add("KMA02123");
+      add("KMA02124");
+      add("KMA02125");
+      add("KMA02126");
+    }};
+
+    englishThreeFourCode.forEach( lectureCode -> {
+      Optional<Lecture> byLectureCode = lectureRepository.findByLectureCode(LectureCode.of(lectureCode));
+      byLectureCode.ifPresent(lecture -> commonCultureMap.get("ENGLISH").add(LectureResponse.from(lecture)));
+    });
   }
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/service/GraduationRequirementServiceImpl.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/service/GraduationRequirementServiceImpl.java
@@ -99,7 +99,7 @@ public class GraduationRequirementServiceImpl implements GraduationRequirementSe
       if(!lecture.isRevoked()){
         switch (lectureCategory.getCategory().name()) {
           case "MAJOR":
-            divideMajorByMandatory(majorMap, graduationLecture, lecture);
+            divideMajorByMandatory(majorMap, graduationLecture, lectureCategory, lecture);
             break;
           case "COMMON_CULTURE":
             commonCultureMap.computeIfAbsent(lectureCategory.getDetailCategory(), k -> new ArrayList<>())
@@ -117,11 +117,16 @@ public class GraduationRequirementServiceImpl implements GraduationRequirementSe
   }
 
   private void divideMajorByMandatory(Map<String, List<LectureResponse>> majorMap, GraduationLecture graduationLecture,
-                                Lecture lecture) {
+                                      LectureCategory lectureCategory, Lecture lecture) {
     if(graduationLecture.isMandatory()){
       majorMap.get("전공필수").add(LectureResponse.from(lecture));
     }
     else{
+      String detailCategory = lectureCategory.getDetailCategory();
+      if(detailCategory.charAt(detailCategory.length()-1)=='A') {
+        String addedLectureName = lecture.getName() + "(선택필수)";
+        lecture.setName(addedLectureName);
+      }
       majorMap.get("전공선택").add(LectureResponse.from(lecture));
     }
   }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/service/GraduationRequirementServiceImpl.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/service/GraduationRequirementServiceImpl.java
@@ -61,15 +61,12 @@ public class GraduationRequirementServiceImpl implements GraduationRequirementSe
             DEFAULT_ENGLISH_LV
     );
 
-    Map<String, List<LectureResponse>> majorMap = new HashMap<>(){{
-      put("전공필수", new ArrayList<>());
-      put("전공선택", new ArrayList<>());
-    }};
+    Map<String, List<LectureResponse>> majorMap = new HashMap<>(){};
     Map<String, List<LectureResponse>> commonCultureMap = new HashMap<>();
     Map<String, List<LectureResponse>> coreCultureMap = new HashMap<>();
-    Map<String, List<LectureResponse>> basicAcademicalCultureMap = new HashMap<>(){{
-      put("학문기초교양", new ArrayList<>());
-    }};
+    Map<String, List<LectureResponse>> basicAcademicalCultureMap = new HashMap<>(){};
+
+    initializeMap(majorMap, basicAcademicalCultureMap);
 
     classifyGraduationLectures(graduationLectures, majorMap, commonCultureMap, coreCultureMap, basicAcademicalCultureMap);
 
@@ -161,4 +158,12 @@ public class GraduationRequirementServiceImpl implements GraduationRequirementSe
       byLectureCode.ifPresent(lecture -> commonCultureMap.get("ENGLISH").add(LectureResponse.from(lecture)));
     });
   }
+
+  private void initializeMap(Map<String, List<LectureResponse>> majorMap,
+                             Map<String, List<LectureResponse>> basicAcademicalCultureMap) {
+    majorMap.put("전공필수", new ArrayList<>());
+    majorMap.put("전공선택", new ArrayList<>());
+    basicAcademicalCultureMap.put("학문기초교양", new ArrayList<>());
+  }
+
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/lecture/entity/Lecture.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/lecture/entity/Lecture.java
@@ -86,6 +86,8 @@ public class Lecture extends BaseEntity {
     this.isMajor = true;
   }
 
+  public void setName(String name) {this.name = name;}
+
   public String getCode() {
     return lectureCode.getCode();
   }


### PR DESCRIPTION
## ✅ 작업 내용
- 학번과 과목별로 학사 정보에 있는 들어야하는 과목정보를 카테고리 별로 보여주는 기능입니다.
- 전공에서 전공선택필수 과목과 교양에서 필수적으로 들어야하는 과목들 같은 경우는 따로 체크를 진행하였습니다.

## 🤔 고민 했던 부분
- 카테고리를 세부 카테고리 별로 나누는 과정에서 카테고리를 나누고 다시 세부카테고리를 나누는것은 비효율적이라 판단해 카테고리를 나누면서 세부 카테고리를 동시에 나누는 방법에 대해 고민했습니다. 

