### PR TITLE
일반교양/자유선택 졸업 계산

### DIFF
--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/DetailCategoryResult.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/DetailCategoryResult.java
@@ -1,5 +1,7 @@
 package com.plzgraduate.myongjigraduatebe.graduation.domain.model;
 
+import static com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory.*;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -73,8 +75,9 @@ public class DetailCategoryResult {
 	private void calculateLeftCredit() {
 		int leftCredit = takenCredits - totalCredits;
 		if (leftCredit > 0) {
-			if (detailCategoryName.equals("전공")) {
+			if (detailCategoryName.equals(MAJOR.getName())) {
 				freeElectiveLeftCredit = leftCredit;
+				return;
 			}
 			normalLeftCredit = leftCredit;
 		}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/DetailGraduationResult.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/DetailGraduationResult.java
@@ -24,7 +24,8 @@ public class DetailGraduationResult {
 		this.detailCategory = detailCategory;
 	}
 
-	public static DetailGraduationResult create(GraduationCategory graduationCategory, int totalCredit, List<DetailCategoryResult> detailCategoryResults) {
+	public static DetailGraduationResult create(GraduationCategory graduationCategory, int totalCredit,
+		List<DetailCategoryResult> detailCategoryResults) {
 		return DetailGraduationResult.builder()
 			.categoryName(graduationCategory.getName())
 			.isCompleted(checkIsCompleted(detailCategoryResults))
@@ -34,11 +35,16 @@ public class DetailGraduationResult {
 			.build();
 	}
 
-	public int getLeftCredit() {
-		if(totalCredit>=takenCredit) {
-			return 0;
-		}
-		return takenCredit - totalCredit;
+	public int getNormalLeftCredit() {
+		return detailCategory.stream()
+			.mapToInt(DetailCategoryResult::getNormalLeftCredit)
+			.sum();
+	}
+
+	public int getFreeElectiveLeftCredit() {
+		return detailCategory.stream()
+			.mapToInt(DetailCategoryResult::getFreeElectiveLeftCredit)
+			.sum();
 	}
 
 	private static boolean checkIsCompleted(List<DetailCategoryResult> detailCategoryResults) {

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/FreeElectiveGraduationResult.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/FreeElectiveGraduationResult.java
@@ -1,0 +1,55 @@
+package com.plzgraduate.myongjigraduatebe.graduation.domain.model;
+
+import static com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory.*;
+
+import java.util.List;
+
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class FreeElectiveGraduationResult {
+
+	private final String categoryName;
+	private boolean isCompleted;
+	private final int totalCredit;
+	private final int takenCredit;
+
+	@Builder
+	private FreeElectiveGraduationResult(String categoryName, boolean isCompleted, int totalCredit, int takenCredit) {
+		this.categoryName = categoryName;
+		this.isCompleted = isCompleted;
+		this.totalCredit = totalCredit;
+		this.takenCredit = takenCredit;
+	}
+
+	public static FreeElectiveGraduationResult create(int totalCredit, TakenLectureInventory takenLectureInventory,
+		List<DetailGraduationResult> detailGraduationResults, int leftNormalCultureCredit) {
+		return FreeElectiveGraduationResult.builder()
+			.categoryName(FREE_ELECTIVE.getName())
+			.isCompleted(false)
+			.totalCredit(totalCredit)
+			.takenCredit(
+				calculateTakenCredit(takenLectureInventory, detailGraduationResults, leftNormalCultureCredit))
+			.build();
+	}
+
+	public void checkCompleted() {
+		this.isCompleted = takenCredit >= totalCredit;
+	}
+
+	private static int calculateTakenCredit(TakenLectureInventory takenLectureInventory,
+		List<DetailGraduationResult> detailGraduationResults, int leftNormalCultureCredit) {
+		int remainCreditByDetailGraduationResult = detailGraduationResults.stream()
+			.mapToInt(DetailGraduationResult::getFreeElectiveLeftCredit)
+			.sum();
+
+		int remainCreditByTakenLectures = takenLectureInventory.getTakenLectures().stream()
+			.mapToInt(takenLecture -> takenLecture.getLecture().getCredit())
+			.sum();
+
+		return remainCreditByDetailGraduationResult + remainCreditByTakenLectures + leftNormalCultureCredit;
+	}
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/NormalCultureGraduationResult.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/NormalCultureGraduationResult.java
@@ -1,0 +1,64 @@
+package com.plzgraduate.myongjigraduatebe.graduation.domain.model;
+
+import static com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory.*;
+
+import java.util.List;
+import java.util.Set;
+
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLecture;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class NormalCultureGraduationResult {
+
+	private final String categoryName;
+	private boolean isCompleted;
+	private final int totalCredit;
+	private final int takenCredit;
+
+	@Builder
+	private NormalCultureGraduationResult(String categoryName, boolean isCompleted, int totalCredit, int takenCredit) {
+		this.categoryName = categoryName;
+		this.isCompleted = isCompleted;
+		this.totalCredit = totalCredit;
+		this.takenCredit = takenCredit;
+	}
+
+	public static NormalCultureGraduationResult create(int totalCredit, TakenLectureInventory takenLectureInventory,
+		List<DetailGraduationResult> detailGraduationResults) {
+		return NormalCultureGraduationResult.builder()
+			.categoryName(NORMAL_CULTURE.getName())
+			.isCompleted(false)
+			.totalCredit(totalCredit)
+			.takenCredit(calculateTakenCredit(takenLectureInventory, detailGraduationResults)).build();
+	}
+
+	public void checkCompleted() {
+		this.isCompleted = takenCredit >= totalCredit;
+	}
+
+	public int getLeftCredit() {
+		if (totalCredit >= takenCredit) {
+			return 0;
+		}
+		return takenCredit - totalCredit;
+	}
+
+	private static int calculateTakenCredit(TakenLectureInventory takenLectureInventory,
+		List<DetailGraduationResult> detailGraduationResults) {
+		int remainCreditByDetailGraduationResult = detailGraduationResults.stream()
+			.mapToInt(DetailGraduationResult::getNormalLeftCredit)
+			.sum();
+
+		Set<TakenLecture> remainTakenNormalCultures = takenLectureInventory.getCultureLectures();
+		int remainCreditByTakenLectures = remainTakenNormalCultures.stream()
+			.mapToInt(takenLecture -> takenLecture.getLecture().getCredit())
+			.sum();
+
+		takenLectureInventory.handleFinishedTakenLectures(remainTakenNormalCultures);
+		return remainCreditByDetailGraduationResult + remainCreditByTakenLectures;
+	}
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/GraduationManager.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/GraduationManager.java
@@ -3,10 +3,10 @@ package com.plzgraduate.myongjigraduatebe.graduation.domain.service;
 import java.util.Set;
 
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailGraduationResult;
-import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLecture;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.StudentInformation;
 
 public interface GraduationManager<T> {
-	DetailGraduationResult createDetailGraduationResult(StudentInformation studentInformation, Set<TakenLecture> takenLectures,
-		Set<T> graduationLectures, int graduationResultTotalCredit);
+	DetailGraduationResult createDetailGraduationResult(StudentInformation studentInformation,
+		TakenLectureInventory takenLectureInventory, Set<T> graduationLectures, int graduationResultTotalCredit);
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/basicacademicalculture/BusinessBasicAcademicalManager.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/basicacademicalculture/BusinessBasicAcademicalManager.java
@@ -11,6 +11,7 @@ import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailGraduatio
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.BasicAcademicalCulture;
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.Lecture;
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLecture;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.StudentInformation;
 
 public class BusinessBasicAcademicalManager implements BasicAcademicalManager {
@@ -35,8 +36,8 @@ public class BusinessBasicAcademicalManager implements BasicAcademicalManager {
 
 	@Override
 	public DetailGraduationResult createDetailGraduationResult(StudentInformation studentInformation,
-		Set<TakenLecture> takenLectures,
-		Set<BasicAcademicalCulture> graduationLectures, int basicAcademicalCredit) {
+		TakenLectureInventory takenLectureInventory, Set<BasicAcademicalCulture> graduationLectures,
+		int basicAcademicalCredit) {
 		Set<Lecture> basicAcademicalLectures = convertToLectureSet(graduationLectures);
 
 		Set<TakenLecture> removedTakenLecture = new HashSet<>();
@@ -44,13 +45,13 @@ public class BusinessBasicAcademicalManager implements BasicAcademicalManager {
 		Set<Lecture> finalBasicAcademicalLectures = resetBasicAcademicalLectureSet(basicAcademicalLectures,
 			studentInformation);
 
-		takenLectures.stream()
+		takenLectureInventory.getTakenLectures().stream()
 			.filter(takenLecture -> finalBasicAcademicalLectures.contains(takenLecture.getLecture()))
 			.forEach(takenLecture -> {
 				removedTakenLecture.add(takenLecture);
 				taken.add(takenLecture.getLecture());
 			});
-		takenLectures.removeAll(removedTakenLecture);
+		takenLectureInventory.handleFinishedTakenLectures(removedTakenLecture);
 
 		DetailCategoryResult detailCategoryResult = DetailCategoryResult.create(
 			BASIC_ACADEMICAL_CULTURE.getName(), true, basicAcademicalCredit);

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/basicacademicalculture/DefaultBasicAcademicalManager.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/basicacademicalculture/DefaultBasicAcademicalManager.java
@@ -11,6 +11,7 @@ import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailGraduatio
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.BasicAcademicalCulture;
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.Lecture;
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLecture;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.StudentInformation;
 
 import lombok.NoArgsConstructor;
@@ -25,21 +26,21 @@ public class DefaultBasicAcademicalManager implements BasicAcademicalManager {
 
 	@Override
 	public DetailGraduationResult createDetailGraduationResult(StudentInformation studentInformation,
-		Set<TakenLecture> takenLectures,
-		Set<BasicAcademicalCulture> graduationLectures, int basicAcademicalCredit) {
+		TakenLectureInventory takenLectureInventory, Set<BasicAcademicalCulture> graduationLectures,
+		int basicAcademicalCredit) {
 
 		Set<Lecture> basicAcademicalLectures = convertToLectureSet(graduationLectures);
 
 		Set<TakenLecture> removedTakenLecture = new HashSet<>();
 		Set<Lecture> taken = new HashSet<>();
 
-		takenLectures.stream()
+		takenLectureInventory.getTakenLectures().stream()
 			.filter(takenLecture -> basicAcademicalLectures.contains(takenLecture.getLecture()))
 			.forEach(takenLecture -> {
 				removedTakenLecture.add(takenLecture);
 				taken.add(takenLecture.getLecture());
 			});
-		takenLectures.removeAll(removedTakenLecture);
+		takenLectureInventory.handleFinishedTakenLectures(removedTakenLecture);
 
 		DetailCategoryResult detailCategoryResult = DetailCategoryResult.create(
 			BASIC_ACADEMICAL_CULTURE.getName(), true, basicAcademicalCredit);

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/basicacademicalculture/SocialScienceBasicAcademicManager.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/basicacademicalculture/SocialScienceBasicAcademicManager.java
@@ -11,6 +11,7 @@ import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailGraduatio
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.BasicAcademicalCulture;
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.Lecture;
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLecture;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.StudentInformation;
 
 public class SocialScienceBasicAcademicManager implements BasicAcademicalManager {
@@ -35,13 +36,13 @@ public class SocialScienceBasicAcademicManager implements BasicAcademicalManager
 
 	@Override
 	public DetailGraduationResult createDetailGraduationResult(StudentInformation studentInformation,
-		Set<TakenLecture> takenLectures,
-		Set<BasicAcademicalCulture> graduationLectures, int basicAcademicalCredit) {
+		TakenLectureInventory takenLectureInventory, Set<BasicAcademicalCulture> graduationLectures,
+		int basicAcademicalCredit) {
 		Set<Lecture> basicAcademicalLectures = convertToLectureSet(graduationLectures);
 		Set<TakenLecture> removedTakenLecture = new HashSet<>();
 		Set<Lecture> taken = new HashSet<>();
 
-		takenLectures.stream()
+		takenLectureInventory.getTakenLectures().stream()
 			.filter(takenLecture -> basicAcademicalLectures.contains(takenLecture.getLecture()))
 			.filter(takenLecture -> lecturesAcceptTakenAfter2023.contains(takenLecture.getLecture())
 				&& !takenLecture.takenAfter(TWENTY_THREE_YEAR))
@@ -49,7 +50,7 @@ public class SocialScienceBasicAcademicManager implements BasicAcademicalManager
 				removedTakenLecture.add(takenLecture);
 				taken.add(takenLecture.getLecture());
 			});
-		takenLectures.removeAll(removedTakenLecture);
+		takenLectureInventory.handleFinishedTakenLectures(removedTakenLecture);
 
 		DetailCategoryResult detailCategoryResult = DetailCategoryResult.create(
 			BASIC_ACADEMICAL_CULTURE.getName(), true, basicAcademicalCredit);

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/commonculture/CommonCultureDetailCategoryManager.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/commonculture/CommonCultureDetailCategoryManager.java
@@ -10,12 +10,13 @@ import com.plzgraduate.myongjigraduatebe.lecture.domain.model.CommonCulture;
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.CommonCultureCategory;
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.Lecture;
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLecture;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
 
 class CommonCultureDetailCategoryManager {
 
 	private static final List<String> MANDATORY_LECTURE_CODE_LIST = List.of("KMA02100", "KMA00100", "KMA00101");
 
-	public DetailCategoryResult generate(Set<TakenLecture> takenLectures,
+	public DetailCategoryResult generate(TakenLectureInventory takenLectureInventory,
 		Set<CommonCulture> graduationLectures, CommonCultureCategory category) {
 		Set<Lecture> graduationCommonCultureLectures = categorizeCommonCultures(
 			graduationLectures, category);
@@ -23,7 +24,7 @@ class CommonCultureDetailCategoryManager {
 		Set<TakenLecture> removedTakenLecture = new HashSet<>();
 		Set<Lecture> taken = new HashSet<>();
 
-		takenLectures.stream()
+		takenLectureInventory.getTakenLectures().stream()
 			.filter(takenLecture -> graduationCommonCultureLectures.contains(takenLecture.getLecture()))
 			.forEach(takenLecture -> {
 				removedTakenLecture.add(takenLecture);
@@ -31,17 +32,18 @@ class CommonCultureDetailCategoryManager {
 			});
 
 		DetailCategoryResult commonCultureDetailCategoryResult = DetailCategoryResult.create(
-			category.getName(), checkMandatorySatisfaction(takenLectures, category), category.getTotalCredit());
+			category.getName(), checkMandatorySatisfaction(takenLectureInventory, category), category.getTotalCredit());
 		commonCultureDetailCategoryResult.calculate(taken, graduationCommonCultureLectures);
 
-		takenLectures.removeAll(removedTakenLecture);
+		takenLectureInventory.handleFinishedTakenLectures(removedTakenLecture);
 
 		return commonCultureDetailCategoryResult;
 	}
 
-	private boolean checkMandatorySatisfaction(Set<TakenLecture> takenLectures, CommonCultureCategory category) {
+	private boolean checkMandatorySatisfaction(TakenLectureInventory takenLectureInventory,
+		CommonCultureCategory category) {
 		if (category == CommonCultureCategory.CHRISTIAN_A) {
-			return takenLectures.stream()
+			return takenLectureInventory.getTakenLectures().stream()
 				.anyMatch(
 					takenLecture -> MANDATORY_LECTURE_CODE_LIST.contains(takenLecture.getLecture().getLectureCode()));
 		}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/commonculture/CommonCultureGraduationManager.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/commonculture/CommonCultureGraduationManager.java
@@ -12,20 +12,20 @@ import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailGraduatio
 import com.plzgraduate.myongjigraduatebe.graduation.domain.service.GraduationManager;
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.CommonCulture;
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.CommonCultureCategory;
-import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLecture;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.StudentInformation;
 
 public class CommonCultureGraduationManager implements GraduationManager<CommonCulture> {
 
 	@Override
 	public DetailGraduationResult createDetailGraduationResult(StudentInformation studentInformation,
-		Set<TakenLecture> takenLectures,
-		Set<CommonCulture> graduationLectures, int commonCultureGraduationTotalCredit) {
+		TakenLectureInventory takenLectureInventory, Set<CommonCulture> graduationLectures,
+		int commonCultureGraduationTotalCredit) {
 		CommonCultureDetailCategoryManager commonCultureDetailCategoryManager = new CommonCultureDetailCategoryManager();
 		List<DetailCategoryResult> commonCultureDetailCategoryResults = Arrays.stream(CommonCultureCategory.values())
 			.filter(
 				commonCultureCategory -> commonCultureCategory.isContainsEntryYear(studentInformation.getEntryYear()))
-			.map(commonCultureCategory -> commonCultureDetailCategoryManager.generate(takenLectures,
+			.map(commonCultureCategory -> commonCultureDetailCategoryManager.generate(takenLectureInventory,
 				graduationLectures, commonCultureCategory))
 			.collect(Collectors.toList());
 

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/coreculture/CoreCultureDetailCategoryManager.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/coreculture/CoreCultureDetailCategoryManager.java
@@ -12,6 +12,7 @@ import com.plzgraduate.myongjigraduatebe.lecture.domain.model.CoreCulture;
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.CoreCultureCategory;
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.Lecture;
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLecture;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.StudentInformation;
 
 public class CoreCultureDetailCategoryManager {
@@ -25,19 +26,20 @@ public class CoreCultureDetailCategoryManager {
 		Lecture.from("KMA02155"),
 		Lecture.from("KMA02156"));
 
-	public DetailCategoryResult generate(StudentInformation studentInformation, Set<TakenLecture> takenLectures,
-		Set<CoreCulture> graduationLectures, CoreCultureCategory category) {
+	public DetailCategoryResult generate(StudentInformation studentInformation,
+		TakenLectureInventory takenLectureInventory, Set<CoreCulture> graduationLectures,
+		CoreCultureCategory category) {
 		Set<Lecture> graduationCoreCultureLectures = categorizeCommonCultures(graduationLectures, category);
 		Set<TakenLecture> finishedTakenLecture = new HashSet<>();
 		Set<Lecture> taken = new HashSet<>();
 
-		takenLectures.stream()
+		takenLectureInventory.getTakenLectures().stream()
 			.filter(takenLecture -> graduationCoreCultureLectures.contains(takenLecture.getLecture()))
 			.forEach(takenLecture -> {
 				finishedTakenLecture.add(takenLecture);
 				taken.add(takenLecture.getLecture());
 			});
-		takenLectures.removeAll(finishedTakenLecture);
+		takenLectureInventory.handleFinishedTakenLectures(finishedTakenLecture);
 
 		DetailCategoryResult commonCultureDetailCategoryResult = DetailCategoryResult.create(
 			category.getName(), true, category.getTotalCredit());

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/coreculture/CoreCultureGraduationManager.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/coreculture/CoreCultureGraduationManager.java
@@ -12,16 +12,16 @@ import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailGraduatio
 import com.plzgraduate.myongjigraduatebe.graduation.domain.service.GraduationManager;
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.CoreCulture;
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.CoreCultureCategory;
-import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLecture;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.StudentInformation;
 
 public class CoreCultureGraduationManager implements GraduationManager<CoreCulture> {
 	@Override
 	public DetailGraduationResult createDetailGraduationResult(StudentInformation studentInformation,
-		Set<TakenLecture> takenLectures, Set<CoreCulture> graduationLectures, int coreCultureGraduationTotalCredit) {
+		TakenLectureInventory takenLectureInventory, Set<CoreCulture> graduationLectures, int coreCultureGraduationTotalCredit) {
 		CoreCultureDetailCategoryManager coreCultureDetailCategoryManager = new CoreCultureDetailCategoryManager();
 		List<DetailCategoryResult> coreCultureDetailCategoryResults = Arrays.stream(CoreCultureCategory.values())
-			.map(coreCultureCategory -> coreCultureDetailCategoryManager.generate(studentInformation, takenLectures,
+			.map(coreCultureCategory -> coreCultureDetailCategoryManager.generate(studentInformation, takenLectureInventory,
 				graduationLectures, coreCultureCategory))
 			.collect(Collectors.toList());
 

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/major/ElectiveMajorManager.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/major/ElectiveMajorManager.java
@@ -6,13 +6,14 @@ import java.util.Set;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailCategoryResult;
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.Lecture;
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLecture;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
 
 public class ElectiveMajorManager {
-	public DetailCategoryResult createDetailCategoryResult(Set<TakenLecture> takenLectures,
+	public DetailCategoryResult createDetailCategoryResult(TakenLectureInventory takenLectureInventory,
 		Set<Lecture> electiveLectures, int electiveMajorTotalCredit) {
 		Set<Lecture> takenElective = new HashSet<>();
 		Set<TakenLecture> finishedTakenLecture = new HashSet<>();
-		takenLectures.stream()
+		takenLectureInventory.getTakenLectures().stream()
 			.filter(takenLecture -> electiveLectures.contains(takenLecture.getLecture()))
 			.forEach(takenLecture -> {
 				finishedTakenLecture.add(takenLecture);
@@ -20,7 +21,7 @@ public class ElectiveMajorManager {
 			});
 		DetailCategoryResult electiveMajorResult = DetailCategoryResult.create("전공선택", true, electiveMajorTotalCredit);
 		electiveMajorResult.calculate(takenElective, electiveLectures);
-		takenLectures.removeAll(finishedTakenLecture);
+		takenLectureInventory.handleFinishedTakenLectures(finishedTakenLecture);
 
 		return electiveMajorResult;
 	}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/major/MajorManager.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/major/MajorManager.java
@@ -15,31 +15,31 @@ import com.plzgraduate.myongjigraduatebe.graduation.domain.service.major.excepti
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.Lecture;
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.Major;
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLecture;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.StudentInformation;
 
 public class MajorManager implements GraduationManager<Major> {
 
 	@Override
 	public DetailGraduationResult createDetailGraduationResult(StudentInformation studentInformation,
-		Set<TakenLecture> takenLectures, Set<Major> majorLectures, int graduationResultTotalCredit) {
-
-		removeDuplicateLecture(takenLectures, majorLectures);
+		TakenLectureInventory takenLectureInventory, Set<Major> majorLectures, int graduationResultTotalCredit) {
+		removeDuplicateLecture(takenLectureInventory, majorLectures);
 		changeMandatoryToElectiveByMajorRange(studentInformation, majorLectures);
 
 		Set<Lecture> mandatoryLectures = filterMandatoryLectures(majorLectures);
 		Set<Lecture> electiveLectures = filterElectiveLectures(majorLectures);
 
-		List<MajorExceptionHandler> majorExceptionHandlers = List.of(new OptionalMandatoryHandler(), new ReplaceMandatoryMajorHandler());
+		List<MajorExceptionHandler> majorExceptionHandlers = List.of(new OptionalMandatoryHandler(),
+			new ReplaceMandatoryMajorHandler());
 		MandatoryMajorManager mandatoryMajorManager = new MandatoryMajorManager(majorExceptionHandlers);
 		ElectiveMajorManager electiveMajorManager = new ElectiveMajorManager();
 
 		DetailCategoryResult mandantoryDetailCategoryResult = mandatoryMajorManager.createDetailCategoryResult(
-			studentInformation, takenLectures,
-			mandatoryLectures, electiveLectures);
+			studentInformation, takenLectureInventory, mandatoryLectures, electiveLectures);
 
 		int electiveMajorTotalCredit = graduationResultTotalCredit - mandantoryDetailCategoryResult.getTotalCredits();
 		DetailCategoryResult electiveDetailCategoryResult = electiveMajorManager.createDetailCategoryResult(
-			takenLectures, electiveLectures, electiveMajorTotalCredit);
+			takenLectureInventory, electiveLectures, electiveMajorTotalCredit);
 
 		return DetailGraduationResult.create(MAJOR, graduationResultTotalCredit,
 			List.of(mandantoryDetailCategoryResult, electiveDetailCategoryResult));
@@ -59,19 +59,20 @@ public class MajorManager implements GraduationManager<Major> {
 			.collect(Collectors.toSet());
 	}
 
-	private void removeDuplicateLecture(Set<TakenLecture> takenLectures, Set<Major> graduationLectures) {
-		Set<Lecture> duplicatedTakenLectures = findDuplicatedTakenLecture(takenLectures);
+	private void removeDuplicateLecture(TakenLectureInventory takenLectureInventory, Set<Major> graduationLectures) {
+		Set<Lecture> duplicatedTakenLectures = findDuplicatedTakenLecture(takenLectureInventory);
 		graduationLectures.removeIf(graduationLecture ->
 			duplicatedTakenLectures.stream()
 				.anyMatch(duplicatedTakenLecture ->
 					!duplicatedTakenLecture.equals(graduationLecture.getLecture())
-						&& duplicatedTakenLecture.getDuplicateCode().equals(graduationLecture.getLecture().getDuplicateCode())
+						&& duplicatedTakenLecture.getDuplicateCode()
+						.equals(graduationLecture.getLecture().getDuplicateCode())
 				)
 		);
 	}
 
-	private Set<Lecture> findDuplicatedTakenLecture(Set<TakenLecture> takenLectures) {
-		return takenLectures.stream()
+	private Set<Lecture> findDuplicatedTakenLecture(TakenLectureInventory takenLectureInventory) {
+		return takenLectureInventory.getTakenLectures().stream()
 			.map(TakenLecture::getLecture)
 			.filter(lecture -> lecture.getDuplicateCode() != null && lecture.getIsRevoked() == 1)
 			.collect(Collectors.toSet());

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/major/MandatoryMajorManager.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/major/MandatoryMajorManager.java
@@ -8,6 +8,7 @@ import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailCategoryR
 import com.plzgraduate.myongjigraduatebe.graduation.domain.service.major.exception.MajorExceptionHandler;
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.Lecture;
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLecture;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.StudentInformation;
 
 import lombok.RequiredArgsConstructor;
@@ -18,20 +19,21 @@ public class MandatoryMajorManager {
 	private final List<MajorExceptionHandler> majorExceptionHandlers;
 
 	public DetailCategoryResult createDetailCategoryResult(StudentInformation studentInformation,
-		Set<TakenLecture> takenLectures, Set<Lecture> mandatoryLectures, Set<Lecture> electiveLectures) {
+		TakenLectureInventory takenLectureInventory, Set<Lecture> mandatoryLectures, Set<Lecture> electiveLectures) {
 		Set<Lecture> takenMandatory = new HashSet<>();
 		Set<TakenLecture> finishedTakenLecture = new HashSet<>();
 		boolean isSatisfiedMandatory = true;
 		int removeMandatoryTotalCredit = 0;
 
-		for(MajorExceptionHandler majorExceptionHandler: majorExceptionHandlers) {
-			if(majorExceptionHandler.isSupport(studentInformation)) {
-				isSatisfiedMandatory = majorExceptionHandler.checkMandatoryCondition(studentInformation, takenLectures, mandatoryLectures, electiveLectures);
+		for (MajorExceptionHandler majorExceptionHandler : majorExceptionHandlers) {
+			if (majorExceptionHandler.isSupport(studentInformation)) {
+				isSatisfiedMandatory = majorExceptionHandler.checkMandatoryCondition(studentInformation,
+					takenLectureInventory, mandatoryLectures, electiveLectures);
 				removeMandatoryTotalCredit = majorExceptionHandler.getRemovedMandatoryTotalCredit();
 			}
 		}
 
-		takenLectures.stream()
+		takenLectureInventory.getTakenLectures().stream()
 			.filter(takenLecture -> mandatoryLectures.contains(takenLecture.getLecture()))
 			.forEach(takenLecture -> {
 				finishedTakenLecture.add(takenLecture);
@@ -40,14 +42,14 @@ public class MandatoryMajorManager {
 		DetailCategoryResult majorMandatoryResult = DetailCategoryResult.create("전공필수", isSatisfiedMandatory,
 			calculateTotalCredit(takenMandatory, mandatoryLectures, removeMandatoryTotalCredit));
 		majorMandatoryResult.calculate(takenMandatory, mandatoryLectures);
-		takenLectures.removeAll(finishedTakenLecture);
+		takenLectureInventory.handleFinishedTakenLectures(finishedTakenLecture);
 		return majorMandatoryResult;
 	}
 
 	private int calculateTotalCredit(Set<Lecture> taken, Set<Lecture> mandatoryLectures, int removedCredit) {
 		int totalCredit = 0;
-		for(Lecture lecture: mandatoryLectures) {
-			if(!taken.contains(lecture) && lecture.getIsRevoked()==1) {
+		for (Lecture lecture : mandatoryLectures) {
+			if (!taken.contains(lecture) && lecture.getIsRevoked() == 1) {
 				continue;
 			}
 			totalCredit += lecture.getCredit();

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/major/exception/MajorExceptionHandler.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/major/exception/MajorExceptionHandler.java
@@ -3,13 +3,13 @@ package com.plzgraduate.myongjigraduatebe.graduation.domain.service.major.except
 import java.util.Set;
 
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.Lecture;
-import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLecture;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.StudentInformation;
 
 public interface MajorExceptionHandler {
 	boolean isSupport(StudentInformation studentInformation);
 
-	boolean checkMandatoryCondition(StudentInformation studentInformation, Set<TakenLecture> takenLectures,
+	boolean checkMandatoryCondition(StudentInformation studentInformation, TakenLectureInventory takenLectureInventory,
 		Set<Lecture> mandatoryLectures, Set<Lecture> electiveLectures);
 
 	int getRemovedMandatoryTotalCredit();

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/major/exception/OptionalMandatoryHandler.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/major/exception/OptionalMandatoryHandler.java
@@ -7,10 +7,12 @@ import java.util.stream.Collectors;
 
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.Lecture;
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLecture;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.StudentInformation;
 
 public class OptionalMandatoryHandler implements MajorExceptionHandler {
 	private int removedMandatoryTotalCredit = 0;
+
 	public boolean isSupport(StudentInformation studentInformation) {
 		if (studentInformation.getDepartment().equals("경영정보학과") && studentInformation.getEntryYear() >= 19) {
 			return true;
@@ -19,12 +21,13 @@ public class OptionalMandatoryHandler implements MajorExceptionHandler {
 	}
 
 	@Override
-	public boolean checkMandatoryCondition(StudentInformation studentInformation, Set<TakenLecture> takenLectures,
-		Set<Lecture> mandatoryLectures, Set<Lecture> electiveLectures) {
-		boolean checkMandatoryCondition = checkCompleteOptionalMandatory(studentInformation, takenLectures, mandatoryLectures,
+	public boolean checkMandatoryCondition(StudentInformation studentInformation,
+		TakenLectureInventory takenLectureInventory, Set<Lecture> mandatoryLectures, Set<Lecture> electiveLectures) {
+		boolean checkMandatoryCondition = checkCompleteOptionalMandatory(studentInformation, takenLectureInventory,
+			mandatoryLectures,
 			electiveLectures);
 
-		if(!checkMandatoryCondition) {
+		if (!checkMandatoryCondition) {
 			OptionalMandatory optionalMandatory = OptionalMandatory.from(studentInformation);
 			removedMandatoryTotalCredit = optionalMandatory.getTotalOptionalMandatoryCredit(optionalMandatory)
 				- optionalMandatory.getChooseLectureCredit(optionalMandatory);
@@ -37,21 +40,21 @@ public class OptionalMandatoryHandler implements MajorExceptionHandler {
 		return removedMandatoryTotalCredit;
 	}
 
-	public boolean checkCompleteOptionalMandatory(StudentInformation studentInformation, Set<TakenLecture> takenLectures,
-		Set<Lecture> mandatoryLectures, Set<Lecture> electiveLectures) {
+	public boolean checkCompleteOptionalMandatory(StudentInformation studentInformation,
+		TakenLectureInventory takenLectureInventory, Set<Lecture> mandatoryLectures, Set<Lecture> electiveLectures) {
 		OptionalMandatory optionalMandatory = OptionalMandatory.from(studentInformation);
 		int chooseNum = optionalMandatory.getChooseNUmber();
 		Set<Lecture> optionalMandatoryLectures = mandatoryLectures.stream().filter(
 			optionalMandatory.getOptionalMandatoryLectures()::contains).collect(Collectors.toSet());
 		Set<Lecture> remainingMandatoryLectures = new HashSet<>(optionalMandatoryLectures);
 		int count = 0;
-		for (TakenLecture takenLecture : takenLectures) {
+		for (TakenLecture takenLecture : takenLectureInventory.getTakenLectures()) {
 			if (optionalMandatoryLectures.contains(takenLecture.getLecture()) && count < chooseNum) {
 				count++;
 				remainingMandatoryLectures.remove(takenLecture.getLecture());
 			}
 		}
-		if(count >= chooseNum) {
+		if (count >= chooseNum) {
 			electiveLectures.addAll(remainingMandatoryLectures);
 			mandatoryLectures.removeAll(remainingMandatoryLectures);
 		}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/major/exception/ReplaceMandatoryMajorHandler.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/major/exception/ReplaceMandatoryMajorHandler.java
@@ -1,24 +1,23 @@
 package com.plzgraduate.myongjigraduatebe.graduation.domain.service.major.exception;
 
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.Lecture;
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLecture;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.StudentInformation;
 
 public class ReplaceMandatoryMajorHandler implements MajorExceptionHandler {
 	private int removedMandatoryTotalCredit = 0;
 	private static final List<Lecture> REPLACED_LECTURES = List.of(
-		Lecture.of("HAI01110", "답사1", 1,1, null),
-		Lecture.of("HAI01111", "답사2", 1,1, "HAI01111")
+		Lecture.of("HAI01110", "답사1", 1, 1, null),
+		Lecture.of("HAI01111", "답사2", 1, 1, "HAI01111")
 	);
 	private static final List<Lecture> REPLACING_LECTURES = List.of(
-		Lecture.of("HAI01348", "신유학의이해", 3, 0 , null),
+		Lecture.of("HAI01348", "신유학의이해", 3, 0, null),
 		Lecture.of("HAI01247", "유학사상의이해", 3, 0, null)
 	);
 
@@ -28,10 +27,11 @@ public class ReplaceMandatoryMajorHandler implements MajorExceptionHandler {
 	}
 
 	@Override
-	public boolean checkMandatoryCondition(StudentInformation studentInformation, Set<TakenLecture> takenLectures,
-		Set<Lecture> mandatoryLectures, Set<Lecture> electiveLectures) {
-		boolean checkCondition = checkCompleteReplaceMandatory(takenLectures, mandatoryLectures, electiveLectures);
-		if(!checkCondition) {
+	public boolean checkMandatoryCondition(StudentInformation studentInformation,
+		TakenLectureInventory takenLectureInventory, Set<Lecture> mandatoryLectures, Set<Lecture> electiveLectures) {
+		boolean checkCondition = checkCompleteReplaceMandatory(takenLectureInventory, mandatoryLectures,
+			electiveLectures);
+		if (!checkCondition) {
 			removedMandatoryTotalCredit = 3;
 		}
 		return checkCondition;
@@ -42,13 +42,13 @@ public class ReplaceMandatoryMajorHandler implements MajorExceptionHandler {
 		return removedMandatoryTotalCredit;
 	}
 
-	public boolean checkCompleteReplaceMandatory(Set<TakenLecture> takenLectures,
+	public boolean checkCompleteReplaceMandatory(TakenLectureInventory takenLectureInventory,
 		Set<Lecture> mandatoryLectures, Set<Lecture> electiveLectures) {
-		if(checkTakeReplacedLectures(takenLectures)) {
+		if (checkTakeReplacedLectures(takenLectureInventory)) {
 			return true;
 		}
-		List<TakenLecture> replacingLectures = filterTakenLecturesContainsReplacingLectures(takenLectures);
-		if(!replacingLectures.isEmpty()) {
+		List<TakenLecture> replacingLectures = filterTakenLecturesContainsReplacingLectures(takenLectureInventory);
+		if (!replacingLectures.isEmpty()) {
 			mandatoryLectures.add(replacingLectures.get(0).getLecture());
 			electiveLectures.remove(replacingLectures.get(0).getLecture());
 			return true;
@@ -58,15 +58,16 @@ public class ReplaceMandatoryMajorHandler implements MajorExceptionHandler {
 		return false;
 	}
 
-	private boolean checkTakeReplacedLectures(Set<TakenLecture> takenLectures) {
-		long replacedTaken = takenLectures.stream().map(TakenLecture::getLecture)
+	private boolean checkTakeReplacedLectures(TakenLectureInventory takenLectureInventory) {
+		long replacedTaken = takenLectureInventory.getTakenLectures().stream()
+			.map(TakenLecture::getLecture)
 			.filter(REPLACED_LECTURES::contains).count();
 		return replacedTaken == REPLACED_LECTURES.size();
 	}
 
-	private List<TakenLecture> filterTakenLecturesContainsReplacingLectures(Set<TakenLecture> takenLectures) {
-		List<TakenLecture> takenLectureList = new ArrayList<>(takenLectures);
-		return takenLectureList.stream()
+	private List<TakenLecture> filterTakenLecturesContainsReplacingLectures(
+		TakenLectureInventory takenLectureInventory) {
+		return takenLectureInventory.getTakenLectures().stream()
 			.filter(takenLecture -> REPLACING_LECTURES.contains(takenLecture.getLecture()))
 			.sorted(Comparator
 				.comparingInt(TakenLecture::getYear)

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/lecture/domain/model/Lecture.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/lecture/domain/model/Lecture.java
@@ -8,6 +8,8 @@ import lombok.Getter;
 @Getter
 public class Lecture {
 
+	private static final String CULTURE_CODE_START_PREFIX = "KM";
+
 	private final String lectureCode;
 	private final String name;
 	private final int credit;
@@ -37,6 +39,10 @@ public class Lecture {
 			.isRevoked(isRevoked)
 			.duplicateCode(duplicateCode)
 			.build();
+	}
+
+	public boolean isCulture() {
+		return lectureCode.startsWith(CULTURE_CODE_START_PREFIX);
 	}
 
 	@Override

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/takenlecture/domain/model/TakenLectureInventory.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/takenlecture/domain/model/TakenLectureInventory.java
@@ -2,6 +2,7 @@ package com.plzgraduate.myongjigraduatebe.takenlecture.domain.model;
 
 import java.util.Collections;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
 
@@ -12,6 +13,12 @@ public class TakenLectureInventory {
 
 	public Set<TakenLecture> getTakenLectures() {
 		return Collections.unmodifiableSet(takenLecture);
+	}
+
+	public Set<TakenLecture> getCultureLectures() {
+		return takenLecture.stream()
+			.filter(taken -> taken.getLecture().isCulture())
+			.collect(Collectors.toSet());
 	}
 
 	public void handleFinishedTakenLectures(Set<TakenLecture> finishedTakenLecture) {

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/takenlecture/domain/model/TakenLectureInventory.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/takenlecture/domain/model/TakenLectureInventory.java
@@ -1,0 +1,20 @@
+package com.plzgraduate.myongjigraduatebe.takenlecture.domain.model;
+
+import java.util.Collections;
+import java.util.Set;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class TakenLectureInventory {
+
+	private final Set<TakenLecture> takenLecture;
+
+	public Set<TakenLecture> getTakenLectures() {
+		return Collections.unmodifiableSet(takenLecture);
+	}
+
+	public void handleFinishedTakenLectures(Set<TakenLecture> finishedTakenLecture) {
+		takenLecture.removeAll(finishedTakenLecture);
+	}
+}

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/FreeElectiveGraduationResultTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/FreeElectiveGraduationResultTest.java
@@ -1,0 +1,71 @@
+package com.plzgraduate.myongjigraduatebe.graduation.domain.model;
+
+import static com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory.FREE_ELECTIVE;
+import static com.plzgraduate.myongjigraduatebe.lecture.domain.model.CommonCultureCategory.CHRISTIAN_A;
+import static com.plzgraduate.myongjigraduatebe.lecture.domain.model.CoreCultureCategory.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.plzgraduate.myongjigraduatebe.fixture.LectureFixture;
+import com.plzgraduate.myongjigraduatebe.fixture.UserFixture;
+import com.plzgraduate.myongjigraduatebe.lecture.domain.model.Lecture;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.Semester;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLecture;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
+
+class FreeElectiveGraduationResultTest {
+
+	Map<String, Lecture> mockLectureMap = LectureFixture.getMockLectureMap();
+
+	@DisplayName("처리되지 않은 전공 수강과목과 다른 카테고리(공통, 핵심, 학문기초교양, 전공, 일반교양)의 남은 자유선택 학점으로 자유선택 졸업 결과를 생성한다.")
+	@Test
+	void createFreeElectiveGraduationResult() {
+		//given
+		User user = UserFixture.경영학과_19학번();
+		Set<TakenLecture> takenLectures = new HashSet<>((Set.of(
+			TakenLecture.of(user, mockLectureMap.get("HBX01104"), 2019, Semester.FIRST), //회계원리
+			TakenLecture.of(user, mockLectureMap.get("HBX01113"), 2019, Semester.FIRST), //인적자원관리
+			TakenLecture.of(user, mockLectureMap.get("HBX01106"), 2020, Semester.FIRST), //마케팅원론
+			TakenLecture.of(user, mockLectureMap.get("HBX01105"), 2020, Semester.SECOND), //재무관리원론
+			TakenLecture.of(user, mockLectureMap.get("HBX01143"), 2021, Semester.FIRST) //운영관리
+		)));
+		TakenLectureInventory takenLectureInventory = new TakenLectureInventory(takenLectures);
+
+		DetailGraduationResult detailGraduationResult = DetailGraduationResult.builder()
+			.categoryName(FREE_ELECTIVE.getName())
+			.detailCategory(List.of(
+				DetailCategoryResult.builder()
+					.detailCategoryName(CHRISTIAN_A.getName())
+					.freeElectiveLeftCredit(3).build(),
+				DetailCategoryResult.builder()
+					.detailCategoryName(SCIENCE_TECHNOLOGY.getName())
+					.freeElectiveLeftCredit(3).build()
+			)).build();
+
+		int remainCreditByTakenLectures = takenLectureInventory.getTakenLectures().stream()
+			.mapToInt(takenLecture -> takenLecture.getLecture().getCredit())
+			.sum();
+		int freeElectiveLeftCredit = detailGraduationResult.getFreeElectiveLeftCredit();
+		int leftNormalCultureCredit = 5;
+
+		//when
+		FreeElectiveGraduationResult freeElectiveGraduationResult = FreeElectiveGraduationResult.create(7,
+			takenLectureInventory, List.of(detailGraduationResult),
+			leftNormalCultureCredit);
+
+		//then
+		assertThat(freeElectiveGraduationResult)
+			.extracting("categoryName", "takenCredit")
+			.contains(FREE_ELECTIVE.getName(),
+				remainCreditByTakenLectures + freeElectiveLeftCredit + leftNormalCultureCredit);
+	}
+
+}

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/NormalCultureGraduationResultTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/NormalCultureGraduationResultTest.java
@@ -1,0 +1,68 @@
+package com.plzgraduate.myongjigraduatebe.graduation.domain.model;
+
+import static com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory.*;
+import static com.plzgraduate.myongjigraduatebe.lecture.domain.model.CommonCultureCategory.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.plzgraduate.myongjigraduatebe.fixture.LectureFixture;
+import com.plzgraduate.myongjigraduatebe.fixture.UserFixture;
+import com.plzgraduate.myongjigraduatebe.lecture.domain.model.Lecture;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.Semester;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLecture;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
+
+class NormalCultureGraduationResultTest {
+
+	Map<String, Lecture> mockLectureMap = LectureFixture.getMockLectureMap();
+
+	@DisplayName("처리되지 않은 일반교양 수강과목과 다른 카테고리(공통, 핵심, 학문기초교양, 전공)의 남은 일반교양 학점으로 일반교양 졸업 결과를 생성한다.")
+	@Test
+	void createNormalCultureGraduationResult() {
+		//given
+		User user = UserFixture.경영학과_19학번();
+		Set<TakenLecture> takenLectures = new HashSet<>((Set.of(
+			TakenLecture.of(user, mockLectureMap.get("KMA00101"), 2019, Semester.FIRST),
+			TakenLecture.of(user, mockLectureMap.get("KMA02102"), 2019, Semester.FIRST),
+			TakenLecture.of(user, mockLectureMap.get("KMA02122"), 2019, Semester.FIRST),
+			TakenLecture.of(user, mockLectureMap.get("KMA02104"), 2023, Semester.FIRST),
+			TakenLecture.of(user, mockLectureMap.get("KMA02141"), 2023, Semester.FIRST)
+			)));
+		TakenLectureInventory takenLectureInventory = new TakenLectureInventory(takenLectures);
+
+		DetailGraduationResult detailGraduationResult = DetailGraduationResult.builder()
+			.categoryName(COMMON_CULTURE.getName())
+			.detailCategory(List.of(
+				DetailCategoryResult.builder()
+					.detailCategoryName(CHRISTIAN_A.getName())
+					.normalLeftCredit(3).build(),
+				DetailCategoryResult.builder()
+					.detailCategoryName(CAREER.getName())
+					.normalLeftCredit(3).build()
+			)).build();
+
+		int remainTakenNormalCultureCredit = takenLectureInventory.getCultureLectures().stream()
+			.mapToInt(takenLecture -> takenLecture.getLecture().getCredit())
+			.sum();
+		int remainCreditByDetailGraduationResult = detailGraduationResult.getNormalLeftCredit();
+
+		//when
+		NormalCultureGraduationResult normalCultureGraduationResult = NormalCultureGraduationResult.create(15,
+			takenLectureInventory,
+			List.of(detailGraduationResult));
+
+		//then
+		assertThat(normalCultureGraduationResult)
+			.extracting("categoryName", "takenCredit")
+			.contains(NORMAL_CULTURE.getName(), remainTakenNormalCultureCredit + remainCreditByDetailGraduationResult);
+	}
+
+}

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/basicacademicalculture/BusinessBasicAcademicalManagerTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/basicacademicalculture/BusinessBasicAcademicalManagerTest.java
@@ -1,7 +1,6 @@
 package com.plzgraduate.myongjigraduatebe.graduation.domain.service.basicacademicalculture;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.filter;
 
 import java.util.HashSet;
 import java.util.Map;
@@ -21,6 +20,7 @@ import com.plzgraduate.myongjigraduatebe.lecture.domain.model.BasicAcademicalCul
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.Lecture;
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.Semester;
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLecture;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.StudentInformation;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
 
@@ -45,12 +45,12 @@ class BusinessBasicAcademicalManagerTest {
 				TakenLecture.of(user, mockLectureMap.get("KMD02114"), 2019, Semester.FIRST),
 				TakenLecture.of(user, mockLectureMap.get("KMD02107"), 2019, Semester.FIRST)
 			)));
-
+			TakenLectureInventory takenLectureInventory = new TakenLectureInventory(takenLectures);
 			BasicAcademicalManager manager = new BusinessBasicAcademicalManager();
 
 			//when
 			DetailGraduationResult detailGraduationResult = manager.createDetailGraduationResult(studentInformation,
-				takenLectures, basicAcademicalLectures, 6);
+				takenLectureInventory, basicAcademicalLectures, 6);
 
 			DetailCategoryResult detailCategoryResult = detailGraduationResult.getDetailCategory().get(0);
 
@@ -79,11 +79,12 @@ class BusinessBasicAcademicalManagerTest {
 				TakenLecture.of(user, mockLectureMap.get("KMD02114"), 2019, Semester.FIRST),
 				TakenLecture.of(user, mockLectureMap.get("KMD02107"), 2019, Semester.FIRST)
 			)));
+			TakenLectureInventory takenLectureInventory = new TakenLectureInventory(takenLectures);
 			BasicAcademicalManager manager = new BusinessBasicAcademicalManager();
 
 			//when
 			DetailGraduationResult detailGraduationResult = manager.createDetailGraduationResult(studentInformation,
-				takenLectures, basicAcademicalLectures, 6);
+				takenLectureInventory, basicAcademicalLectures, 6);
 
 			DetailCategoryResult detailCategoryResult = detailGraduationResult.getDetailCategory().get(0);
 

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/basicacademicalculture/DefaultBasicAcademicalManagerTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/basicacademicalculture/DefaultBasicAcademicalManagerTest.java
@@ -19,6 +19,7 @@ import com.plzgraduate.myongjigraduatebe.lecture.domain.model.BasicAcademicalCul
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.Lecture;
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.Semester;
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLecture;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.StudentInformation;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
 
@@ -44,12 +45,12 @@ class DefaultBasicAcademicalManagerTest {
 				TakenLecture.of(user, mockLectureMap.get("KMB02128"), 2020, Semester.SECOND),
 				TakenLecture.of(user, mockLectureMap.get("KMB02122"), 2021, Semester.FIRST)
 			)));
-
+			TakenLectureInventory takenLectureInventory = new TakenLectureInventory(takenLectures);
 			BasicAcademicalManager manager = new DefaultBasicAcademicalManager();
 
 			//when
 			DetailGraduationResult detailGraduationResult = manager.createDetailGraduationResult(studentInformation,
-				takenLectures, basicAcademicalLectures, 12);
+				takenLectureInventory, basicAcademicalLectures, 12);
 
 			DetailCategoryResult detailCategoryResult = detailGraduationResult.getDetailCategory().get(0);
 
@@ -75,12 +76,12 @@ class DefaultBasicAcademicalManagerTest {
 				TakenLecture.of(user, mockLectureMap.get("KMB02119"), 2019, Semester.FIRST),
 				TakenLecture.of(user, mockLectureMap.get("KMB02120"), 2020, Semester.FIRST)
 			));
-
+			TakenLectureInventory takenLectureInventory = new TakenLectureInventory(takenLectures);
 			BasicAcademicalManager manager = new DefaultBasicAcademicalManager();
 
 			//when
 			DetailGraduationResult detailGraduationResult = manager.createDetailGraduationResult(studentInformation,
-				takenLectures, basicAcademicalLectures, 12);
+				takenLectureInventory, basicAcademicalLectures, 12);
 
 			DetailCategoryResult detailCategoryResult = detailGraduationResult.getDetailCategory().get(0);
 

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/basicacademicalculture/SocialScienceBasicAcademicManagerTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/basicacademicalculture/SocialScienceBasicAcademicManagerTest.java
@@ -19,6 +19,7 @@ import com.plzgraduate.myongjigraduatebe.lecture.domain.model.BasicAcademicalCul
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.Lecture;
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.Semester;
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLecture;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.StudentInformation;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
 
@@ -43,12 +44,12 @@ class SocialScienceBasicAcademicManagerTest {
 				TakenLecture.of(user, mockLectureMap.get("KMD02108"), 2023, Semester.FIRST),
 				TakenLecture.of(user, mockLectureMap.get("KMD02186"), 2023, Semester.SECOND)
 			)));
-
+			TakenLectureInventory takenLectureInventory = new TakenLectureInventory(takenLectures);
 			BasicAcademicalManager manager = new DefaultBasicAcademicalManager();
 
 			//when
 			DetailGraduationResult detailGraduationResult = manager.createDetailGraduationResult(studentInformation,
-				takenLectures, basicAcademicalLectures, 12);
+				takenLectureInventory, basicAcademicalLectures, 12);
 
 			DetailCategoryResult detailCategoryResult = detailGraduationResult.getDetailCategory().get(0);
 
@@ -76,12 +77,12 @@ class SocialScienceBasicAcademicManagerTest {
 				TakenLecture.of(user, mockLectureMap.get("KMD02108"), 2020, Semester.FIRST),
 				TakenLecture.of(user, mockLectureMap.get("KMD02186"), 2020, Semester.SECOND)
 			)));
-
+			TakenLectureInventory takenLectureInventory = new TakenLectureInventory(takenLectures);
 			BasicAcademicalManager manager = new SocialScienceBasicAcademicManager();
 
 			//when
 			DetailGraduationResult detailGraduationResult = manager.createDetailGraduationResult(studentInformation,
-				takenLectures, basicAcademicalLectures, 12);
+				takenLectureInventory, basicAcademicalLectures, 12);
 			DetailCategoryResult detailCategoryResult = detailGraduationResult.getDetailCategory().get(0);
 
 			//then

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/commonculture/CommonCultureDetailCategoryManagerTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/commonculture/CommonCultureDetailCategoryManagerTest.java
@@ -22,6 +22,7 @@ import com.plzgraduate.myongjigraduatebe.lecture.domain.model.CommonCultureCateg
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.Lecture;
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.Semester;
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLecture;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
 
 @DisplayName("각 공통교양 세부 카테고리 별 카테고리 이름, 총 학점, 이수 여부를 포함한 카테고리 졸업 결과를 생성한다.")
@@ -52,11 +53,12 @@ class CommonCultureDetailCategoryManagerTest {
 			TakenLecture.of(user, mockLectureMap.get("KMA02125"), 2023, Semester.FIRST),
 			TakenLecture.of(user, mockLectureMap.get("KMA02126"), 2023, Semester.FIRST)
 		)));
+		TakenLectureInventory takenLectureInventory = new TakenLectureInventory(takenLectures);
 		String commonCultureCategoryName = commonCultureCategory.getName();
 		int categoryTotalCredit = commonCultureCategory.getTotalCredit();
 
 		//when
-		DetailCategoryResult detailCategoryResult = manager.generate(takenLectures, graduationLectures,
+		DetailCategoryResult detailCategoryResult = manager.generate(takenLectureInventory, graduationLectures,
 			commonCultureCategory);
 
 		//then
@@ -71,12 +73,12 @@ class CommonCultureDetailCategoryManagerTest {
 	void generateUnCompletedCommonCultureDetailCategory(CommonCultureCategory commonCultureCategory,
 		Set<CommonCulture> graduationLectures) {
 		//given
-		Set<TakenLecture> takenLectures = new HashSet<>();
+		TakenLectureInventory takenLectureInventory = new TakenLectureInventory(new HashSet<>());
 		String commonCultureCategoryName = commonCultureCategory.getName();
 		int categoryTotalCredit = commonCultureCategory.getTotalCredit();
 
 		//when
-		DetailCategoryResult detailCategoryResult = manager.generate(takenLectures, graduationLectures,
+		DetailCategoryResult detailCategoryResult = manager.generate(takenLectureInventory, graduationLectures,
 			commonCultureCategory);
 
 		//then
@@ -97,10 +99,11 @@ class CommonCultureDetailCategoryManagerTest {
 			TakenLecture.of(user, mockLectureMap.get("KMA02104"), 2023, Semester.FIRST),
 			TakenLecture.of(user, mockLectureMap.get("KMA02141"), 2023, Semester.FIRST)
 		)));
+		TakenLectureInventory takenLectureInventory = new TakenLectureInventory(takenLectures);
 		Set<CommonCulture> graduationLectures = 공통교양_16_17(); // == 공통교양_18_19
 
 		//when
-		DetailCategoryResult detailCategoryResult = manager.generate(takenLectures, graduationLectures, CHRISTIAN_A);
+		DetailCategoryResult detailCategoryResult = manager.generate(takenLectureInventory, graduationLectures, CHRISTIAN_A);
 
 		//then
 		assertThat(detailCategoryResult)
@@ -118,10 +121,11 @@ class CommonCultureDetailCategoryManagerTest {
 			TakenLecture.of(user, mockLectureMap.get("KMA02122"), 2023, Semester.FIRST),
 			TakenLecture.of(user, mockLectureMap.get("KMA02103"), 2023, Semester.FIRST)
 		)));
+		TakenLectureInventory takenLectureInventory = new TakenLectureInventory(takenLectures);
 		Set<CommonCulture> graduationLectures = 공통교양_16_17(); // == 공통교양_18_19
 
 		//when
-		DetailCategoryResult detailCategoryResult = manager.generate(takenLectures, graduationLectures, CHRISTIAN_A);
+		DetailCategoryResult detailCategoryResult = manager.generate(takenLectureInventory, graduationLectures, CHRISTIAN_A);
 
 		//then
 		assertThat(detailCategoryResult)

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/commonculture/CommonCultureGraduationManagerTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/commonculture/CommonCultureGraduationManagerTest.java
@@ -19,6 +19,7 @@ import com.plzgraduate.myongjigraduatebe.lecture.domain.model.CommonCulture;
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.Lecture;
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.Semester;
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLecture;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.StudentInformation;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
 
@@ -49,10 +50,11 @@ class CommonCultureGraduationManagerTest {
 			TakenLecture.of(user, mockLectureMap.get("KMA02125"), 2023, Semester.FIRST),
 			TakenLecture.of(user, mockLectureMap.get("KMA02126"), 2023, Semester.FIRST)
 		)));
+		TakenLectureInventory takenLectureInventory = new TakenLectureInventory(takenLectures);
 
 		//when
 		DetailGraduationResult detailGraduationResult = graduationManager.createDetailGraduationResult(
-			studentInformation, takenLectures, graduationLectures, 17);
+			studentInformation, takenLectureInventory, graduationLectures, 17);
 		//then
 		assertThat(detailGraduationResult)
 			.extracting("categoryName", "isCompleted")
@@ -70,10 +72,11 @@ class CommonCultureGraduationManagerTest {
 			TakenLecture.of(user, mockLectureMap.get("KMA02104"), 2023, Semester.FIRST),
 			TakenLecture.of(user, mockLectureMap.get("KMA02141"), 2023, Semester.FIRST)
 		)));
+		TakenLectureInventory takenLectureInventory = new TakenLectureInventory(takenLectures);
 
 		//when
 		DetailGraduationResult detailGraduationResult = graduationManager.createDetailGraduationResult(
-			studentInformation, takenLectures, graduationLectures, 17);
+			studentInformation, takenLectureInventory, graduationLectures, 17);
 		//then
 		assertThat(detailGraduationResult)
 			.extracting("categoryName", "isCompleted")

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/coreculture/CoreCultureDetailCategoryManagerTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/coreculture/CoreCultureDetailCategoryManagerTest.java
@@ -25,6 +25,7 @@ import com.plzgraduate.myongjigraduatebe.lecture.domain.model.CoreCultureCategor
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.Lecture;
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.Semester;
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLecture;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
 
 @DisplayName("각 핵심교양 세부 카테고리 별 카테고리 이름, 총 학점, 이수 여부를 포함한 카테고리 졸업 결과를 생성한다.")
@@ -65,13 +66,13 @@ class CoreCultureDetailCategoryManagerTest {
 			TakenLecture.of(user, mockLectureMap.get("KMA02138"), 2023, Semester.FIRST),
 			TakenLecture.of(user, mockLectureMap.get("KMA02139"), 2023, Semester.FIRST)
 		)));
+		TakenLectureInventory takenLectureInventory = new TakenLectureInventory(takenLectures);
 		String coreCultureCategoryName = coreCultureCategory.getName();
 		int categoryTotalCredit = coreCultureCategory.getTotalCredit();
 
 		//when
-		DetailCategoryResult detailCategoryResult = manager.generate(user.getStudentInformation(), takenLectures,
-			graduationLectures,
-			coreCultureCategory);
+		DetailCategoryResult detailCategoryResult = manager.generate(user.getStudentInformation(),
+			takenLectureInventory, graduationLectures, coreCultureCategory);
 
 		//then
 		assertThat(detailCategoryResult)
@@ -86,13 +87,13 @@ class CoreCultureDetailCategoryManagerTest {
 		Set<CoreCulture> graduationLectures) {
 		//given
 		User user = UserFixture.경영학과_19학번();
-		Set<TakenLecture> takenLectures = new HashSet<>();
+		TakenLectureInventory takenLectureInventory = new TakenLectureInventory(new HashSet<>());
 		String coreCultureCategoryName = coreCultureCategory.getName();
 		int categoryTotalCredit = coreCultureCategory.getTotalCredit();
 
 		//when
-		DetailCategoryResult detailCategoryResult = manager.generate(user.getStudentInformation(), takenLectures,
-			graduationLectures, coreCultureCategory);
+		DetailCategoryResult detailCategoryResult = manager.generate(user.getStudentInformation(),
+			takenLectureInventory, graduationLectures, coreCultureCategory);
 
 		//then
 		assertThat(detailCategoryResult)
@@ -110,13 +111,14 @@ class CoreCultureDetailCategoryManagerTest {
 			TakenLecture.of(user, mockLectureMap.get("KMA02136"), 2019, Semester.FIRST),
 			TakenLecture.of(user, mockLectureMap.get("KMA02138"), 2019, Semester.FIRST)
 		)));
+		TakenLectureInventory takenLectureInventory = new TakenLectureInventory(takenLectures);
 		Set<CoreCulture> graduationLectures = 핵심교양_과학과기술();
 		CoreCultureCategory coreCultureCategory = SCIENCE_TECHNOLOGY;
 		int categoryTotalCredit = coreCultureCategory.getTotalCredit();
 
 		//when
-		DetailCategoryResult detailCategoryResult = manager.generate(user.getStudentInformation(), takenLectures,
-			graduationLectures, coreCultureCategory);
+		DetailCategoryResult detailCategoryResult = manager.generate(user.getStudentInformation(),
+			takenLectureInventory, graduationLectures, coreCultureCategory);
 
 		//then
 		assertThat(detailCategoryResult)
@@ -124,6 +126,7 @@ class CoreCultureDetailCategoryManagerTest {
 				"freeElectiveLeftCredit")
 			.contains(coreCultureCategory.getName(), true, categoryTotalCredit, 3, 3);
 	}
+
 	static Stream<Arguments> ictUsers() {
 		return Stream.of(
 			Arguments.arguments(UserFixture.응용소프트웨어학과_19학번()),
@@ -135,21 +138,22 @@ class CoreCultureDetailCategoryManagerTest {
 	@DisplayName("4차산업혁명시대의예술, 문화리터러시와창의적스토리텔링 과목은 2022년 1학기에 수강한 경우에는 핵심교양이 아닌 일반교양으로 인정된다.")
 	@Test
 	void generateUnCompletedCultureArtDetailCategoryResultWith_2022_First() {
-	    //given
+		//given
 		User user = UserFixture.경영학과_19학번();
 		Set<TakenLecture> takenLectures = new HashSet<>((Set.of(
 			TakenLecture.of(user, mockLectureMap.get("KMA02155"), 2022, Semester.FIRST),
 			TakenLecture.of(user, mockLectureMap.get("KMA02156"), 2022, Semester.FIRST)
 		)));
+		TakenLectureInventory takenLectureInventory = new TakenLectureInventory(takenLectures);
 		Set<CoreCulture> graduationLectures = 핵심교양_문화와예술();
 		CoreCultureCategory coreCultureCategory = CULTURE_ART;
 		int categoryTotalCredit = coreCultureCategory.getTotalCredit();
 
-	    //when
-		DetailCategoryResult detailCategoryResult = manager.generate(user.getStudentInformation(), takenLectures,
-			graduationLectures, coreCultureCategory);
+		//when
+		DetailCategoryResult detailCategoryResult = manager.generate(user.getStudentInformation(),
+			takenLectureInventory, graduationLectures, coreCultureCategory);
 
-	    //then
+		//then
 		assertThat(detailCategoryResult)
 			.extracting("detailCategoryName", "isCompleted", "totalCredits", "normalLeftCredit",
 				"freeElectiveLeftCredit")

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/coreculture/CoreCultureGraduationManagerTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/coreculture/CoreCultureGraduationManagerTest.java
@@ -18,6 +18,7 @@ import com.plzgraduate.myongjigraduatebe.lecture.domain.model.CoreCulture;
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.Lecture;
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.Semester;
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLecture;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.StudentInformation;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
 
@@ -57,12 +58,13 @@ class CoreCultureGraduationManagerTest {
 			TakenLecture.of(user, mockLectureMap.get("KMA02138"), 2023, Semester.FIRST),
 			TakenLecture.of(user, mockLectureMap.get("KMA02139"), 2023, Semester.FIRST)
 		)));
+		TakenLectureInventory takenLectureInventory = new TakenLectureInventory(takenLectures);
 		StudentInformation studentInformation = user.getStudentInformation();
 		Set<CoreCulture> graduationLectures = CoreCultureFixture.getAllCoreCulture();
 
 		//when
 		DetailGraduationResult detailGraduationResult = graduationManager.createDetailGraduationResult(
-			studentInformation, takenLectures, graduationLectures, 12);
+			studentInformation, takenLectureInventory, graduationLectures, 12);
 
 		//then
 		assertThat(detailGraduationResult)
@@ -88,12 +90,13 @@ class CoreCultureGraduationManagerTest {
 			TakenLecture.of(user, mockLectureMap.get("KMA02142"), 2023, Semester.FIRST),
 			TakenLecture.of(user, mockLectureMap.get("KMA02160"), 2023, Semester.FIRST)
 		)));
+		TakenLectureInventory takenLectureInventory = new TakenLectureInventory(takenLectures);
 
 		Set<CoreCulture> graduationLectures = CoreCultureFixture.getAllCoreCulture();
 
 		//when
 		DetailGraduationResult detailGraduationResult = graduationManager.createDetailGraduationResult(
-			studentInformation, takenLectures, graduationLectures, 12);
+			studentInformation, takenLectureInventory, graduationLectures, 12);
 		//then
 		assertThat(detailGraduationResult)
 			.extracting("categoryName", "isCompleted")

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/major/DataTechnologyMajorTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/major/DataTechnologyMajorTest.java
@@ -19,6 +19,7 @@ import com.plzgraduate.myongjigraduatebe.lecture.domain.model.Lecture;
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.Major;
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.Semester;
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLecture;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.StudentInformation;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
 
@@ -30,7 +31,6 @@ class DataTechnologyMajorTest {
 	@Test
 	void 전공필수_기준학점_충족 () {
 		//given
-
 		User user = UserFixture.데이테크놀로지학과_16학번();
 		StudentInformation studentInformation = user.getStudentInformation();
 		Set<TakenLecture> takenLectures = new HashSet<>((Set.of(
@@ -64,13 +64,13 @@ class DataTechnologyMajorTest {
 			TakenLecture.of(user, mockLectureMap.get("HED01311"), 2021, Semester.SECOND) //자기주도학
 
 		)));
-
+		TakenLectureInventory takenLectureInventory = new TakenLectureInventory(takenLectures);
 		Set<Major> 데이터테크놀로지_전공 = MajorFixture.데이터테크놀로지_전공();
 		MajorManager manager = new MajorManager();
 
 		//when
 		DetailGraduationResult detailGraduationResult = manager.createDetailGraduationResult(studentInformation,
-			takenLectures, 데이터테크놀로지_전공, 70);
+			takenLectureInventory, 데이터테크놀로지_전공, 70);
 		List<DetailCategoryResult> detailCategory = detailGraduationResult.getDetailCategory();
 		DetailCategoryResult mandatoryDetailCategory = detailCategory.get(0);
 		DetailCategoryResult electiveDetailCategory = detailCategory.get(1);
@@ -121,13 +121,13 @@ class DataTechnologyMajorTest {
 			TakenLecture.of(user, mockLectureMap.get("HED01404"), 2023, Semester.FIRST), //빅데이터프로그래밍1
 			TakenLecture.of(user, mockLectureMap.get("HED01407"), 2023, Semester.FIRST) //딥러닝
 		)));
-
+		TakenLectureInventory takenLectureInventory = new TakenLectureInventory(takenLectures);
 		Set<Major> 데이터테크놀로지_전공 = MajorFixture.데이터테크놀로지_전공();
 		MajorManager manager = new MajorManager();
 
 		//when
 		DetailGraduationResult detailGraduationResult = manager.createDetailGraduationResult(studentInformation,
-			takenLectures, 데이터테크놀로지_전공, 70);
+			takenLectureInventory, 데이터테크놀로지_전공, 70);
 		List<DetailCategoryResult> detailCategory = detailGraduationResult.getDetailCategory();
 		DetailCategoryResult mandatoryDetailCategory = detailCategory.get(0);
 		DetailCategoryResult electiveDetailCategory = detailCategory.get(1);

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/major/InternationTradeMajorTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/major/InternationTradeMajorTest.java
@@ -19,6 +19,7 @@ import com.plzgraduate.myongjigraduatebe.lecture.domain.model.Lecture;
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.Major;
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.Semester;
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLecture;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.StudentInformation;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
 
@@ -57,13 +58,13 @@ class InternationTradeMajorTest {
 			TakenLecture.of(user, mockLectureMap.get("HCC04343"), 2022, Semester.SECOND), //해외시장조사론
 			TakenLecture.of(user, mockLectureMap.get("HCC04496"), 2022, Semester.SECOND) //글로벌전략계획
 		)));
-
+		TakenLectureInventory takenLectureInventory = new TakenLectureInventory(takenLectures);
 		Set<Major> 국제통상_전공 = MajorFixture.국제통상_전공();
 		MajorManager manager = new MajorManager();
 
 		//when
 		DetailGraduationResult detailGraduationResult = manager.createDetailGraduationResult(studentInformation,
-			takenLectures, 국제통상_전공, 63);
+			takenLectureInventory, 국제통상_전공, 63);
 		List<DetailCategoryResult> detailCategory = detailGraduationResult.getDetailCategory();
 		DetailCategoryResult mandatoryDetailCategory = detailCategory.get(0);
 		DetailCategoryResult electiveDetailCategory = detailCategory.get(1);
@@ -112,13 +113,13 @@ class InternationTradeMajorTest {
 			TakenLecture.of(user, mockLectureMap.get("HCC04343"), 2022, Semester.SECOND), //해외시장조사론
 			TakenLecture.of(user, mockLectureMap.get("HCC04496"), 2022, Semester.SECOND) //글로벌전략계획
 		)));
-
+		TakenLectureInventory takenLectureInventory = new TakenLectureInventory(takenLectures);
 		Set<Major> 국제통상_전공 = MajorFixture.국제통상_전공();
 		MajorManager manager = new MajorManager();
 
 		//when
 		DetailGraduationResult detailGraduationResult = manager.createDetailGraduationResult(studentInformation,
-			takenLectures, 국제통상_전공, 63);
+			takenLectureInventory, 국제통상_전공, 63);
 		List<DetailCategoryResult> detailCategory = detailGraduationResult.getDetailCategory();
 		DetailCategoryResult mandatoryDetailCategory = detailCategory.get(0);
 		DetailCategoryResult electiveDetailCategory = detailCategory.get(1);
@@ -168,13 +169,13 @@ class InternationTradeMajorTest {
 			TakenLecture.of(user, mockLectureMap.get("HCC04496"), 2022, Semester.SECOND), //글로벌전략계획
 			TakenLecture.of(user, mockLectureMap.get("HCC04426"), 2023, Semester.SECOND) //다국적기업론
 		)));
-
+		TakenLectureInventory takenLectureInventory = new TakenLectureInventory(takenLectures);
 		Set<Major> 국제통상_전공 = MajorFixture.국제통상_전공();
 		MajorManager manager = new MajorManager();
 
 		//when
 		DetailGraduationResult detailGraduationResult = manager.createDetailGraduationResult(studentInformation,
-			takenLectures, 국제통상_전공, 63);
+			takenLectureInventory, 국제통상_전공, 63);
 		List<DetailCategoryResult> detailCategory = detailGraduationResult.getDetailCategory();
 		DetailCategoryResult mandatoryDetailCategory = detailCategory.get(0);
 		DetailCategoryResult electiveDetailCategory = detailCategory.get(1);
@@ -221,13 +222,13 @@ class InternationTradeMajorTest {
 			TakenLecture.of(user, mockLectureMap.get("HCC04456"), 2022, Semester.SECOND), //미국경제론
 			TakenLecture.of(user, mockLectureMap.get("HCC04461"), 2022, Semester.SECOND) //국제통상세미나
 		)));
-
+		TakenLectureInventory takenLectureInventory = new TakenLectureInventory(takenLectures);
 		Set<Major> 국제통상_전공 = MajorFixture.국제통상_전공();
 		MajorManager manager = new MajorManager();
 
 		//when
 		DetailGraduationResult detailGraduationResult = manager.createDetailGraduationResult(studentInformation,
-			takenLectures, 국제통상_전공, 63);
+			takenLectureInventory, 국제통상_전공, 63);
 		List<DetailCategoryResult> detailCategory = detailGraduationResult.getDetailCategory();
 		DetailCategoryResult mandatoryDetailCategory = detailCategory.get(0);
 		DetailCategoryResult electiveDetailCategory = detailCategory.get(1);
@@ -259,13 +260,13 @@ class InternationTradeMajorTest {
 			TakenLecture.of(user, mockLectureMap.get("HBX01105"), 2020, Semester.SECOND), //재무관리원론
 			TakenLecture.of(user, mockLectureMap.get("HBX01143"), 2021, Semester.FIRST) //운영관리
 		)));
-
+		TakenLectureInventory takenLectureInventory = new TakenLectureInventory(takenLectures);
 		Set<Major> 국제통상_전공 = MajorFixture.국제통상_전공();
 		MajorManager manager = new MajorManager();
 
 		//when
 		DetailGraduationResult detailGraduationResult = manager.createDetailGraduationResult(studentInformation,
-			takenLectures, 국제통상_전공, 70);
+			takenLectureInventory, 국제통상_전공, 70);
 		List<DetailCategoryResult> detailCategory = detailGraduationResult.getDetailCategory();
 		DetailCategoryResult mandatoryDetailCategory = detailCategory.get(0);
 		DetailCategoryResult electiveDetailCategory = detailCategory.get(1);
@@ -289,15 +290,14 @@ class InternationTradeMajorTest {
 			TakenLecture.of(user, mockLectureMap.get("HBX01105"), 2020, Semester.SECOND), //재무관리원리
 			TakenLecture.of(user, mockLectureMap.get("HBX01114"), 2021, Semester.FIRST) //생산운영관리
 		)));
-
+		TakenLectureInventory takenLectureInventory = new TakenLectureInventory(takenLectures);
 		Set<Major> 국제통상_전공 = MajorFixture.국제통상_전공();
 		MajorManager manager = new MajorManager();
 
 		//when
 		DetailGraduationResult detailGraduationResult = manager.createDetailGraduationResult(studentInformation,
-			takenLectures, 국제통상_전공, 70);
+			takenLectureInventory, 국제통상_전공, 70);
 		List<DetailCategoryResult> detailCategory = detailGraduationResult.getDetailCategory();
-		DetailCategoryResult mandatoryDetailCategory = detailCategory.get(0);
 		DetailCategoryResult electiveDetailCategory = detailCategory.get(1);
 
 		//then

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/major/exception/ReplaceMandatoryMajorHandlerTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/major/exception/ReplaceMandatoryMajorHandlerTest.java
@@ -1,6 +1,5 @@
 package com.plzgraduate.myongjigraduatebe.graduation.domain.service.major.exception;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.HashSet;
@@ -15,6 +14,7 @@ import com.plzgraduate.myongjigraduatebe.fixture.UserFixture;
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.Lecture;
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.Semester;
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLecture;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.StudentInformation;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
 
@@ -24,11 +24,10 @@ class ReplaceMandatoryMajorHandlerTest {
 	private static final StudentInformation studentInformation = user.getStudentInformation();
 	private static final Map<String, Lecture> mockLectureMap = LectureFixture.getMockLectureMap();
 
-
 	@DisplayName("답사1와 답사2를 수강했을 경우 세부조건을 달성한다.")
 	@Test
 	void 답사과목_수강() {
-	    //given
+		//given
 		Set<Lecture> mandatoryLectures = new HashSet<>(Set.of(
 			mockLectureMap.get("HAI01110"), //답사1
 			mockLectureMap.get("HAI01111"), //답사2
@@ -44,10 +43,12 @@ class ReplaceMandatoryMajorHandlerTest {
 			TakenLecture.of(user, mockLectureMap.get("HAI01111"), 2020, Semester.SECOND), //답사2
 			TakenLecture.of(user, mockLectureMap.get("HAI01348"), 2020, Semester.SECOND) //신유학의이해
 		);
-	    //when
+		TakenLectureInventory takenLectureInventory = new TakenLectureInventory(takenLectures);
+
+		//when
 		MajorExceptionHandler exceptionHandler = new ReplaceMandatoryMajorHandler();
-		boolean checkMandatoryCondition = exceptionHandler.checkMandatoryCondition(studentInformation, takenLectures,
-			mandatoryLectures, electiveLectures);
+		boolean checkMandatoryCondition = exceptionHandler.checkMandatoryCondition(studentInformation,
+			takenLectureInventory, mandatoryLectures, electiveLectures);
 		int removedMandatoryTotalCredit = exceptionHandler.getRemovedMandatoryTotalCredit();
 		//then
 		assertThat(checkMandatoryCondition).isTrue();
@@ -74,10 +75,12 @@ class ReplaceMandatoryMajorHandlerTest {
 			TakenLecture.of(user, mockLectureMap.get("HAI01348"), 2021, Semester.FIRST), //신유학의이해
 			TakenLecture.of(user, mockLectureMap.get("HAI01247"), 2021, Semester.SECOND) //유학사상의이해
 		);
+		TakenLectureInventory takenLectureInventory = new TakenLectureInventory(takenLectures);
+
 		//when
 		MajorExceptionHandler exceptionHandler = new ReplaceMandatoryMajorHandler();
-		boolean checkMandatoryCondition = exceptionHandler.checkMandatoryCondition(studentInformation, takenLectures,
-			mandatoryLectures, electiveLectures);
+		boolean checkMandatoryCondition = exceptionHandler.checkMandatoryCondition(studentInformation,
+			takenLectureInventory, mandatoryLectures, electiveLectures);
 		int removedMandatoryTotalCredit = exceptionHandler.getRemovedMandatoryTotalCredit();
 		//then
 		assertThat(checkMandatoryCondition).isTrue();
@@ -85,7 +88,6 @@ class ReplaceMandatoryMajorHandlerTest {
 		assertThat(mandatoryLectures).hasSize(5).contains(mockLectureMap.get("HAI01348"));
 		assertThat(electiveLectures).hasSize(1).contains(mockLectureMap.get("HAI01247"));
 	}
-
 
 	@DisplayName("답사1,답사2를 수강했을 못했고, 대체과목을 수강하지 못했을 경우 대체과목은 전공필수 과목으로 이동한다.")
 	@Test
@@ -101,11 +103,12 @@ class ReplaceMandatoryMajorHandlerTest {
 			mockLectureMap.get("HAI01348"), //신유학의이해
 			mockLectureMap.get("HAI01247") //유학사상의이해
 		));
-		Set<TakenLecture> takenLectures = new HashSet<>();
+		TakenLectureInventory takenLectureInventory = new TakenLectureInventory(new HashSet<>());
+
 		//when
 		MajorExceptionHandler exceptionHandler = new ReplaceMandatoryMajorHandler();
-		boolean checkMandatoryCondition = exceptionHandler.checkMandatoryCondition(studentInformation, takenLectures,
-			mandatoryLectures, electiveLectures);
+		boolean checkMandatoryCondition = exceptionHandler.checkMandatoryCondition(studentInformation,
+			takenLectureInventory, mandatoryLectures, electiveLectures);
 		int removedMandatoryTotalCredit = exceptionHandler.getRemovedMandatoryTotalCredit();
 		//then
 		assertThat(checkMandatoryCondition).isFalse();

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/lecture/domain/model/LectureTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/lecture/domain/model/LectureTest.java
@@ -1,0 +1,38 @@
+package com.plzgraduate.myongjigraduatebe.lecture.domain.model;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class LectureTest {
+
+	@DisplayName("과목코드가 'KM'으로 시작하는 과목은 교양과목이다.")
+	@Test
+	void checkIsCulture() {
+	    //given
+		String lectureCode = "KMA02100";
+		Lecture lecture = Lecture.from(lectureCode);
+
+		//when
+		boolean isCulture = lecture.isCulture();
+
+		//then
+		assertThat(isCulture).isTrue();
+	}
+
+	@DisplayName("과목코드가 'KM'으로 시작하지 않는 과목은 교양과목이 아니다.")
+	@Test
+	void checkNotIsCulture() {
+		//given
+		String lectureCode = "HEB01102";
+		Lecture lecture = Lecture.from(lectureCode);
+
+		//when
+		boolean isCulture = lecture.isCulture();
+
+		//then
+		assertThat(isCulture).isFalse();
+	}
+
+}

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/takenlecture/domain/model/TakenLectureInventoryTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/takenlecture/domain/model/TakenLectureInventoryTest.java
@@ -1,0 +1,71 @@
+package com.plzgraduate.myongjigraduatebe.takenlecture.domain.model;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.plzgraduate.myongjigraduatebe.fixture.LectureFixture;
+import com.plzgraduate.myongjigraduatebe.fixture.UserFixture;
+import com.plzgraduate.myongjigraduatebe.lecture.domain.model.Lecture;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
+
+class TakenLectureInventoryTest {
+
+	private final User user = UserFixture.경영학과_19학번();
+	private final Map<String, Lecture> mockLectureMap = LectureFixture.getMockLectureMap();
+	private final TakenLectureInventory takenLectureInventory = new TakenLectureInventory(new HashSet<>(Set.of(
+		TakenLecture.of(user, mockLectureMap.get("KMA00101"), 2019, Semester.FIRST),
+		TakenLecture.of(user, mockLectureMap.get("KMA02102"), 2019, Semester.FIRST),
+		TakenLecture.of(user, mockLectureMap.get("KMA02122"), 2019, Semester.FIRST),
+		TakenLecture.of(user, mockLectureMap.get("KMA02104"), 2023, Semester.FIRST),
+		TakenLecture.of(user, mockLectureMap.get("KMA02141"), 2023, Semester.FIRST),
+		TakenLecture.of(user, mockLectureMap.get("KMA02106"), 2023, Semester.FIRST),
+		TakenLecture.of(user, mockLectureMap.get("KMA02107"), 2023, Semester.FIRST),
+		TakenLecture.of(user, mockLectureMap.get("KMA02123"), 2023, Semester.FIRST),
+		TakenLecture.of(user, mockLectureMap.get("KMA02124"), 2023, Semester.FIRST),
+		TakenLecture.of(user, mockLectureMap.get("KMA02108"), 2023, Semester.FIRST),
+		TakenLecture.of(user, mockLectureMap.get("KMA02109"), 2023, Semester.FIRST),
+		TakenLecture.of(user, mockLectureMap.get("KMA02125"), 2023, Semester.FIRST),
+		TakenLecture.of(user, mockLectureMap.get("KMA02126"), 2023, Semester.FIRST)
+	)));
+
+	@DisplayName("수강과목 목록에서 교양 수강과목 목록을 반환한다.")
+	@Test
+	void getTakenCultureLectures() {
+		//given //when
+		Set<TakenLecture> cultureLectures = takenLectureInventory.getCultureLectures();
+
+		//then
+		assertThat(cultureLectures).hasSize(takenLectureInventory.getTakenLectures().size());
+	}
+
+	@DisplayName("수강과목 목록에서 처리 완료된 과목을 제거한다.")
+	@Test
+	void handleFinishedTakenLectures() {
+		//given
+		int beforeHandleSize = takenLectureInventory.getTakenLectures().size();
+		Set<TakenLecture> finishedTakenLecture = new HashSet<>(Set.of(
+			TakenLecture.of(user, mockLectureMap.get("KMA00101"), 2019, Semester.FIRST),
+			TakenLecture.of(user, mockLectureMap.get("KMA02102"), 2019, Semester.FIRST),
+			TakenLecture.of(user, mockLectureMap.get("KMA02122"), 2019, Semester.FIRST),
+			TakenLecture.of(user, mockLectureMap.get("KMA02104"), 2023, Semester.FIRST),
+			TakenLecture.of(user, mockLectureMap.get("KMA02141"), 2023, Semester.FIRST),
+			TakenLecture.of(user, mockLectureMap.get("KMA02106"), 2023, Semester.FIRST),
+			TakenLecture.of(user, mockLectureMap.get("KMA02107"), 2023, Semester.FIRST),
+			TakenLecture.of(user, mockLectureMap.get("KMA02126"), 2023, Semester.FIRST)
+		));
+
+		//when
+		takenLectureInventory.handleFinishedTakenLectures(finishedTakenLecture);
+
+		//then
+		assertThat(takenLectureInventory.getTakenLectures())
+			.hasSize(beforeHandleSize - finishedTakenLecture.size());
+	}
+
+}


### PR DESCRIPTION
## Issue
Close #164 

## ✅ 작업 내용
- 일반 교양 졸업 계산 및 졸업 결과 생성
- 자유 선택 졸업 계산 및 졸업 결과 생성

## 🤔 고민 했던 부분
- 일반 교양, 자유 선택 모두 다른 졸업 카테고리들과는 달리 해당 카테고리를 완료하기 위한 졸업과목, 수강과목이 따로 존재하지 않기 때문에 DetailGraduaionResult로 공통화 하기에는 무리가 있다고 생각했습니다. 따라서 공통 교양, 자유 선택 결과를 따로 계산/생성 하기로 결정했습니다.
- 여러 도메인에 걸쳐 공통적으로 사용되던 Set<TakenLecture>를 계산 결과에 따라 잘 관리해야 하는데 그 부분이 잘 이뤄지지 않았던 것 같습니다. 따라사 해당 컬렉션을 일급 컬렉션으로 만들어 의도치 않은 컬렉션의 변화를 막고 처리된 TakenLecture를 스스로 처리하는 책임을 부여했습니다.

## 🔊 도움이 필요한 부분!!
- 현재 DetailGraduationResult는 팩터리 메서드인 create에 의해 호출되는 private 메서드가 주요 로직입니다. 해당 부분을 public으로 열어 따로 단위 테스트를 해야할 지 혹은 기존에 작성했던 GraduationManager들의 DetailGraduationResult 테스트로 해당 테스트가 만족된 건지 고민이 됩니다.