### PR TITLE
hotfix: 과목 데이터 존재하지 않을 경우 에러 메세지 수정

### DIFF
--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/service/DefaultTakenLectureService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/service/DefaultTakenLectureService.java
@@ -201,7 +201,7 @@ public class DefaultTakenLectureService implements TakenLectureService {
   private Lecture getLectureToLectureCode(LectureCode lectureCode) {
     return lectureRepository
         .findByLectureCode(lectureCode)
-        .orElseThrow(() -> new IllegalArgumentException("본 서비스는 자연캠퍼스 과목이 있을 경우 지원되지 않습니다. 서비스 오류일 경우 채널톡으로 문의 부탁드립니다."));
+        .orElseThrow(() -> new IllegalArgumentException("과목 데이터베이스에 존재하지 않은 과목이 있습니다. 채널톡으로 문의 부탁드립니다."));
   }
 
   private boolean containLectures(


### PR DESCRIPTION
## Issue
Close #177 

## ✅ 작업 내용
- 기존에 사용자 수강과목에서 과목데이터에 존재하지 않은 경우일 경우 "본 서비스는 자연캠퍼스 과목이 있을 경우 지원되지 않습니다. 서비스 오류일 경우 채널톡으로 문의 부탁드립니다." 형식의 에러메시지를 반환했습니다.
- 하지만 인문캠퍼스 과목만 수강을 했을 경우에도 아직 과목 업데이트가 되지 않아 사용자에게 혼란을 주는 경우가 있어 "과목 데이터베이스에 포함되지 않은 과목이 있습니다. 채널톡으로 문의 부탁드립니다." 로 수정했습니다.

