### PR TITLE
아이디 찾기

### DIFF
--- a/src/main/java/com/plzgraduate/myongjigraduatebe/core/config/SecurityConfig.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/core/config/SecurityConfig.java
@@ -42,7 +42,7 @@ public class SecurityConfig {
 			.antMatchers(
 				API_V1_PREFIX + "/users/sign-up", // 회원가입
 				API_V1_PREFIX + "/auth/sign-in", // 로그인
-				API_V1_PREFIX + "/users/student-number/**"
+				API_V1_PREFIX + "/users/student-number/**" // 아이디 찾기
 			)
 			.permitAll()
 			.anyRequest()

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/core/config/SecurityConfig.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/core/config/SecurityConfig.java
@@ -41,7 +41,8 @@ public class SecurityConfig {
 			.authorizeRequests()
 			.antMatchers(
 				API_V1_PREFIX + "/users/sign-up", // 회원가입
-				API_V1_PREFIX + "/auth/sign-in" // 로그인
+				API_V1_PREFIX + "/auth/sign-in", // 로그인
+				API_V1_PREFIX + "/users/student-number/**"
 			)
 			.permitAll()
 			.anyRequest()

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/core/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/core/exception/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 import javax.validation.ConstraintViolation;
@@ -21,13 +22,20 @@ import javax.validation.ConstraintViolationException;
 public class GlobalExceptionHandler {
 
 	@ExceptionHandler({
-		IllegalArgumentException.class, IllegalStateException.class,
+		IllegalArgumentException.class,
+		IllegalStateException.class,
 		HttpMessageNotReadableException.class
 	})
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	public ExceptionResponse handleBadRequestException(Exception e) {
 		log.debug("Bad request exception occurred: {}", e.getMessage(), e);
 		return ExceptionResponse.of(HttpStatus.BAD_REQUEST, getMessage(e));
+	}
+
+	@ExceptionHandler(NoSuchElementException.class)
+	public ExceptionResponse handleNotFoundException(Exception e) {
+		log.debug("Not Found exception occurred: {}", e.getMessage(), e);
+		return ExceptionResponse.of(HttpStatus.NOT_FOUND, getMessage(e));
 	}
 
 	@ExceptionHandler(UnAuthorizedException.class)

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/core/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/core/exception/GlobalExceptionHandler.java
@@ -33,6 +33,7 @@ public class GlobalExceptionHandler {
 	}
 
 	@ExceptionHandler(NoSuchElementException.class)
+	@ResponseStatus(HttpStatus.NOT_FOUND)
 	public ExceptionResponse handleNotFoundException(Exception e) {
 		log.debug("Not Found exception occurred: {}", e.getMessage(), e);
 		return ExceptionResponse.of(HttpStatus.NOT_FOUND, getMessage(e));

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/adaptor/in/web/findauthid/FindAuthIdController.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/adaptor/in/web/findauthid/FindAuthIdController.java
@@ -1,0 +1,24 @@
+package com.plzgraduate.myongjigraduatebe.user.adaptor.in.web.findauthid;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.plzgraduate.myongjigraduatebe.core.meta.WebAdapter;
+import com.plzgraduate.myongjigraduatebe.user.application.port.in.find.FindUserAuthIdUseCase;
+import com.plzgraduate.myongjigraduatebe.user.application.port.in.find.UserAuthIdResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@WebAdapter
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class FindAuthIdController {
+
+	private final FindUserAuthIdUseCase findUserAuthIdUseCase;
+
+	@GetMapping("/student-number/{studentNumber}")
+	public UserAuthIdResponse findUserAuthId(@PathVariable String studentNumber) {
+		return findUserAuthIdUseCase.findUserAuthId(studentNumber);
+	}
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/adaptor/in/web/findauthid/FindAuthIdController.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/adaptor/in/web/findauthid/FindAuthIdController.java
@@ -1,7 +1,7 @@
 package com.plzgraduate.myongjigraduatebe.user.adaptor.in.web.findauthid;
 
+import org.springframework.data.repository.query.Param;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import com.plzgraduate.myongjigraduatebe.core.meta.WebAdapter;
@@ -17,8 +17,8 @@ public class FindAuthIdController {
 
 	private final FindUserAuthIdUseCase findUserAuthIdUseCase;
 
-	@GetMapping("/student-number/{studentNumber}")
-	public UserAuthIdResponse findUserAuthId(@PathVariable String studentNumber) {
+	@GetMapping("/student-number")
+	public UserAuthIdResponse findUserAuthId(@Param("studentNumber") String studentNumber) {
 		return findUserAuthIdUseCase.findUserAuthId(studentNumber);
 	}
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/adaptor/out/persistence/UserPersistenceAdaptor.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/adaptor/out/persistence/UserPersistenceAdaptor.java
@@ -45,6 +45,11 @@ class UserPersistenceAdaptor implements FindUserPort, SaveUserPort, CheckUserPor
 	}
 
 	@Override
+	public Optional<User> findUserByStudentNumber(String studentNumber) {
+		return userRepository.findByStudentNumber(studentNumber).map(userMapper::mapToDomainEntity);
+	}
+
+	@Override
 	public boolean checkDuplicateAuthId(String authId) {
 		return userRepository.existsByAuthId(authId);
 	}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/adaptor/out/persistence/UserRepository.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/adaptor/out/persistence/UserRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface UserRepository extends JpaRepository<UserJpaEntity, Long> {
 	Optional<UserJpaEntity> findByAuthId(String authId);
 
+	Optional<UserJpaEntity> findByStudentNumber(String studentNumber);
+
 	boolean existsByAuthId(String authId);
 
 	boolean existsByStudentNumber(String studentNumber);

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/application/port/in/find/FindUserAuthIdUseCase.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/application/port/in/find/FindUserAuthIdUseCase.java
@@ -1,0 +1,6 @@
+package com.plzgraduate.myongjigraduatebe.user.application.port.in.find;
+
+public interface FindUserAuthIdUseCase {
+
+	UserAuthIdResponse findUserAuthId(String studentNumber);
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/application/port/in/find/UserAuthIdResponse.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/application/port/in/find/UserAuthIdResponse.java
@@ -1,0 +1,25 @@
+package com.plzgraduate.myongjigraduatebe.user.application.port.in.find;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UserAuthIdResponse {
+
+	private String authId;
+	private String studentNumber;
+
+	@Builder
+	private UserAuthIdResponse(String authId, String studentNumber) {
+		this.authId = authId;
+		this.studentNumber = studentNumber;
+	}
+
+	public static UserAuthIdResponse from(String encryptedAutId, String studentNumber) {
+		return UserAuthIdResponse.builder()
+			.authId(encryptedAutId)
+			.studentNumber(studentNumber).build();
+	}
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/application/port/in/find/UserAuthIdResponse.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/application/port/in/find/UserAuthIdResponse.java
@@ -17,7 +17,7 @@ public class UserAuthIdResponse {
 		this.studentNumber = studentNumber;
 	}
 
-	public static UserAuthIdResponse from(String encryptedAutId, String studentNumber) {
+	public static UserAuthIdResponse of(String encryptedAutId, String studentNumber) {
 		return UserAuthIdResponse.builder()
 			.authId(encryptedAutId)
 			.studentNumber(studentNumber).build();

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/application/port/out/FindUserPort.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/application/port/out/FindUserPort.java
@@ -8,4 +8,6 @@ public interface FindUserPort {
 
 	Optional<User> findUserById(Long id);
 	Optional<User> findUserByAuthId(String authId);
+
+	Optional<User> findUserByStudentNumber(String studentNumber);
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/application/service/find/FindUserAuthIdService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/application/service/find/FindUserAuthIdService.java
@@ -22,7 +22,7 @@ public class FindUserAuthIdService implements FindUserAuthIdUseCase {
 	@Override
 	public UserAuthIdResponse findUserAuthId(String studentNumber) {
 		User user = findUserPort.findUserByStudentNumber(studentNumber)
-			.orElseThrow(() -> new NoSuchElementException("해당 학번의 사용자가 존재하지 않습니다"));
+			.orElseThrow(() -> new NoSuchElementException("해당 학번의 사용자가 존재하지 않습니다."));
 		return UserAuthIdResponse.of(user.getEncryptedAuthId(), studentNumber);
 	}
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/application/service/find/FindUserAuthIdService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/application/service/find/FindUserAuthIdService.java
@@ -23,6 +23,6 @@ public class FindUserAuthIdService implements FindUserAuthIdUseCase {
 	public UserAuthIdResponse findUserAuthId(String studentNumber) {
 		User user = findUserPort.findUserByStudentNumber(studentNumber)
 			.orElseThrow(() -> new NoSuchElementException("해당 학번의 사용자가 존재하지 않습니다"));
-		return UserAuthIdResponse.from(user.getEncryptedAuthId(), studentNumber);
+		return UserAuthIdResponse.of(user.getEncryptedAuthId(), studentNumber);
 	}
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/application/service/find/FindUserAuthIdService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/application/service/find/FindUserAuthIdService.java
@@ -1,0 +1,28 @@
+package com.plzgraduate.myongjigraduatebe.user.application.service.find;
+
+import java.util.NoSuchElementException;
+
+import org.springframework.transaction.annotation.Transactional;
+
+import com.plzgraduate.myongjigraduatebe.core.meta.UseCase;
+import com.plzgraduate.myongjigraduatebe.user.application.port.in.find.FindUserAuthIdUseCase;
+import com.plzgraduate.myongjigraduatebe.user.application.port.in.find.UserAuthIdResponse;
+import com.plzgraduate.myongjigraduatebe.user.application.port.out.FindUserPort;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
+
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class FindUserAuthIdService implements FindUserAuthIdUseCase {
+
+	private final FindUserPort findUserPort;
+
+	@Override
+	public UserAuthIdResponse findUserAuthId(String studentNumber) {
+		User user = findUserPort.findUserByStudentNumber(studentNumber)
+			.orElseThrow(() -> new NoSuchElementException("해당 학번의 사용자가 존재하지 않습니다"));
+		return UserAuthIdResponse.from(user.getEncryptedAuthId(), studentNumber);
+	}
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/domain/model/User.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/domain/model/User.java
@@ -79,6 +79,10 @@ public class User {
 			throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
 		}
 	}
+
+	public String getEncryptedAuthId() {
+		return authId.replace(authId.substring(authId.length() - 3), "***");
+	}
 	private static int parseEntryYearInStudentNumber(String studentNumber) {
 		return Integer.parseInt(studentNumber.substring(2, 4));
 	}

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/user/adaptor/in/web/findauthid/FindAuthIdControllerTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/user/adaptor/in/web/findauthid/FindAuthIdControllerTest.java
@@ -1,0 +1,44 @@
+package com.plzgraduate.myongjigraduatebe.user.adaptor.in.web.findauthid;
+
+import static org.hamcrest.Matchers.is;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import com.plzgraduate.myongjigraduatebe.support.WebAdaptorTestSupport;
+import com.plzgraduate.myongjigraduatebe.user.application.port.in.find.FindUserAuthIdUseCase;
+import com.plzgraduate.myongjigraduatebe.user.application.port.in.find.UserAuthIdResponse;
+
+@WebMvcTest(controllers = FindAuthIdController.class)
+class FindAuthIdControllerTest extends WebAdaptorTestSupport {
+
+	@MockBean
+	private FindUserAuthIdUseCase findUserAuthIdUseCase;
+
+	@DisplayName("학번으로 해당 학생의 아이디를 조회한다.")
+	@Test
+	void findUserAuthId() throws Exception {
+	    //given
+		String studentNumber = "60191111";
+		String encryptedAuthId = "test***";
+		UserAuthIdResponse userAuthIdResponse = UserAuthIdResponse.builder()
+			.authId(encryptedAuthId)
+			.studentNumber(studentNumber).build();
+		given(findUserAuthIdUseCase.findUserAuthId(studentNumber)).willReturn(userAuthIdResponse);
+
+		//when //then
+		mockMvc.perform(get("/api/v1/users/student-number/{studentNumber}", studentNumber))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.authId", is(encryptedAuthId)))
+			.andExpect(jsonPath("$.studentNumber", is(studentNumber)));
+	}
+
+}

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/user/adaptor/in/web/findauthid/FindAuthIdControllerTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/user/adaptor/in/web/findauthid/FindAuthIdControllerTest.java
@@ -37,7 +37,8 @@ class FindAuthIdControllerTest extends WebAdaptorTestSupport {
 		given(findUserAuthIdUseCase.findUserAuthId(studentNumber)).willReturn(userAuthIdResponse);
 
 		//when //then
-		mockMvc.perform(get("/api/v1/users/student-number/{studentNumber}", studentNumber))
+		mockMvc.perform(get("/api/v1/users/student-number")
+				.param("studentNumber", studentNumber))
 			.andDo(print())
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.authId", is(encryptedAuthId)))
@@ -53,7 +54,8 @@ class FindAuthIdControllerTest extends WebAdaptorTestSupport {
 			new NoSuchElementException("해당 학번의 사용자가 존재하지 않습니다."));
 
 		//when //then
-		mockMvc.perform(get("/api/v1/users/student-number/{studentNumber}", studentNumber))
+		mockMvc.perform(get("/api/v1/users/student-number")
+				.param("studentNumber", studentNumber))
 			.andDo(print())
 			.andExpect(status().isNotFound())
 			.andExpect(jsonPath("$.status", is(404)))

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/user/adaptor/in/web/findauthid/FindAuthIdControllerTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/user/adaptor/in/web/findauthid/FindAuthIdControllerTest.java
@@ -1,11 +1,14 @@
 package com.plzgraduate.myongjigraduatebe.user.adaptor.in.web.findauthid;
 
 import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.NoSuchElementException;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,7 +28,7 @@ class FindAuthIdControllerTest extends WebAdaptorTestSupport {
 	@DisplayName("학번으로 해당 학생의 아이디를 조회한다.")
 	@Test
 	void findUserAuthId() throws Exception {
-	    //given
+		//given
 		String studentNumber = "60191111";
 		String encryptedAuthId = "test***";
 		UserAuthIdResponse userAuthIdResponse = UserAuthIdResponse.builder()
@@ -39,6 +42,22 @@ class FindAuthIdControllerTest extends WebAdaptorTestSupport {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.authId", is(encryptedAuthId)))
 			.andExpect(jsonPath("$.studentNumber", is(studentNumber)));
+	}
+
+	@DisplayName("학번으로 해당 학생의 아이디를 조회한다.")
+	@Test
+	void findUserAuthIdWithoutUser() throws Exception {
+		//given
+		String studentNumber = "60191111";
+		given(findUserAuthIdUseCase.findUserAuthId(any())).willThrow(
+			new NoSuchElementException("해당 학번의 사용자가 존재하지 않습니다."));
+
+		//when //then
+		mockMvc.perform(get("/api/v1/users/student-number/{studentNumber}", studentNumber))
+			.andDo(print())
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.status", is(404)))
+			.andExpect(jsonPath("$.message", is("해당 학번의 사용자가 존재하지 않습니다.")));
 	}
 
 }

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/user/adaptor/out/persistence/UserPersistenceAdaptorTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/user/adaptor/out/persistence/UserPersistenceAdaptorTest.java
@@ -46,6 +46,22 @@ class UserPersistenceAdaptorTest extends PersistenceTestSupport {
 		assertThat(user.get().getAuthId()).isEqualTo(authId);
 	}
 
+	@DisplayName("학번으로 사용자를 조회한다.")
+	@Test
+	void findUserByStudentNumber() {
+		//given
+		String studentNumber = "60181666";
+		UserJpaEntity userJpaEntity = createUserEntity("mju1001", "1q2w3e4r!", studentNumber);
+		userRepository.save(userJpaEntity);
+
+		//when
+		Optional<User> user = userPersistenceAdaptor.findUserByStudentNumber(studentNumber);
+
+		//then
+		assertThat(user).isPresent();
+		assertThat(user.get().getStudentNumber()).isEqualTo(studentNumber);
+	}
+
 	@DisplayName("아이디가 이미 존재하는지 확인한다.")
 	@Test
 	void 중복_아이디_확인() {

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/user/adaptor/out/persistence/UserRepositoryTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/user/adaptor/out/persistence/UserRepositoryTest.java
@@ -1,6 +1,5 @@
 package com.plzgraduate.myongjigraduatebe.user.adaptor.out.persistence;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.List;
@@ -31,6 +30,22 @@ class UserRepositoryTest extends PersistenceTestSupport {
 		//then
 		assertThat(user).isPresent();
 		assertThat(user.get().getAuthId()).isEqualTo("mju1001");
+	}
+
+	@DisplayName("학번을 통해 유저를 조회한다.")
+	@Test
+	void findByStudentNumber() {
+		//given
+		String studentNumber = "60181666";
+		UserJpaEntity userJpaEntity = createUserEntity("mju1001", "1q2w3e4r!", studentNumber);
+		userRepository.save(userJpaEntity);
+
+		//when
+		Optional<UserJpaEntity> user = userRepository.findByStudentNumber(studentNumber);
+
+		//then
+		assertThat(user).isPresent();
+		assertThat(user.get().getStudentNumber()).isEqualTo(studentNumber);
 	}
 
 	@DisplayName("아이디가 이미 존재하는지 확인한다.")

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/user/application/service/find/FindUserAuthIdServiceTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/user/application/service/find/FindUserAuthIdServiceTest.java
@@ -57,7 +57,7 @@ class FindUserAuthIdServiceTest {
 		//when //then
 		assertThatThrownBy(() -> findUserAuthIdService.findUserAuthId(studentNumber))
 			.isInstanceOf(NoSuchElementException.class)
-			.hasMessage("해당 학번의 사용자가 존재하지 않습니다");
+			.hasMessage("해당 학번의 사용자가 존재하지 않습니다.");
 	}
 
 }

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/user/application/service/find/FindUserAuthIdServiceTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/user/application/service/find/FindUserAuthIdServiceTest.java
@@ -1,0 +1,63 @@
+package com.plzgraduate.myongjigraduatebe.user.application.service.find;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.plzgraduate.myongjigraduatebe.user.application.port.in.find.UserAuthIdResponse;
+import com.plzgraduate.myongjigraduatebe.user.application.port.out.FindUserPort;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
+
+@ExtendWith(MockitoExtension.class)
+class FindUserAuthIdServiceTest {
+
+	@Mock
+	private FindUserPort findUserPort;
+
+	@InjectMocks
+	private FindUserAuthIdService findUserAuthIdService;
+
+	@DisplayName("학번을 통해 해당 학번 학생의 암호화된 로그인 아이디를 얻는다.")
+	@Test
+	void findUserAuthId() {
+	    //given
+		String studentNumber = "60191111";
+		User user = User.builder()
+			.authId("tester00")
+			.password("tester00!")
+			.studentNumber(studentNumber)
+			.build();
+		given(findUserPort.findUserByStudentNumber(anyString())).willReturn(Optional.of(user));
+
+	    //when
+		UserAuthIdResponse userAuthIdResponse = findUserAuthIdService.findUserAuthId(studentNumber);
+
+		//then
+		assertThat(userAuthIdResponse).extracting("authId", "studentNumber")
+			.contains("teste***", studentNumber);
+	}
+
+	@DisplayName("학번에 해당하는 유저가 존재하지 않을 경우 예외가 발생한다.")
+	@Test
+	void findUserAuthIdWithoutUser() {
+		//given
+		String studentNumber = "60191111";
+		given(findUserPort.findUserByStudentNumber(anyString())).willReturn(Optional.empty());
+
+		//when //then
+		assertThatThrownBy(() -> findUserAuthIdService.findUserAuthId(studentNumber))
+			.isInstanceOf(NoSuchElementException.class)
+			.hasMessage("해당 학번의 사용자가 존재하지 않습니다");
+	}
+
+}

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/user/domain/model/UserTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/user/domain/model/UserTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 import static org.mockito.MockitoAnnotations.openMocks;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -56,7 +57,6 @@ class UserTest {
 			.contains("테스터2", "경영학과", "데이터테크놀로지학과", null, StudentCategory.CHANGE_MAJOR);
 	}
 
-
 	@DisplayName("checkBeforeEntryYear 메서드 테스트")
 	@Test
 	void checkBeforeEntryYear() {
@@ -96,5 +96,23 @@ class UserTest {
 		assertThatThrownBy(() -> user.matchPassword(passwordEncoder, "wrongPassword"))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("비밀번호가 일치하지 않습니다.");
+	}
+
+	@DisplayName("유저의 암호화된 로그인 아이디(뒷 세자리 *** 대체)를 반환한다.")
+	@Test
+	void getEncryptedAuthId() {
+		//given
+		String authId = "testAuthId";
+		User user = User.builder()
+			.authId(authId).build();
+
+		//when
+		String encryptedAuthId = user.getEncryptedAuthId();
+
+		//then
+		assertThat(encryptedAuthId.substring(0, encryptedAuthId.length() - 4))
+			.isEqualTo(authId.substring(0, authId.length() - 4));
+		assertThat(encryptedAuthId.substring(encryptedAuthId.length() - 3)).isEqualTo(
+			"***");
 	}
 }

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/user/domain/model/UserTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/user/domain/model/UserTest.java
@@ -1,11 +1,9 @@
 package com.plzgraduate.myongjigraduatebe.user.domain.model;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 import static org.mockito.MockitoAnnotations.openMocks;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## Issue
Close #179 

## ✅ 작업 내용
- 유저 로그인 아이디 찾기 구현

## 🤔 고민 했던 부분

## 🔊 도움이 필요한 부분!!
- 현재 아이디 찾기 api 명세 상 요청 시 전달할 데이터인 학번이 path variable을 통해 전달되고 있습니다. 전달되는 학번의 유저가 존재하는지 알 수 없으며, 해당 자원 조회 시 필요한 조건이니 query parameter를 쓰는게 더 좋을 거 같습니다. 의견 부탁드립니다!.
(다만, 프론트 엔드 개발자와 공유된 내용이 아니기 때문에 기존 api 명세대로 기능 구현 완료했습니다!)
