### PR TITLE
아이디 중복 체크

### DIFF
--- a/src/main/java/com/plzgraduate/myongjigraduatebe/core/config/SecurityConfig.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/core/config/SecurityConfig.java
@@ -40,7 +40,7 @@ public class SecurityConfig {
 		http
 			.authorizeRequests()
 			.antMatchers(
-				API_V1_PREFIX + "/users/sign-up", // 회원가입
+				API_V1_PREFIX + "/users/sign-up/**", // 회원가입
 				API_V1_PREFIX + "/auth/sign-in", // 로그인
 				API_V1_PREFIX + "/users/{student-number}/auth-id", // 아이디 찾기
 				API_V1_PREFIX + "/users/password" // 비밀번호 재설정

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/adaptor/in/web/signup/SignUpController.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/adaptor/in/web/signup/SignUpController.java
@@ -2,11 +2,15 @@ package com.plzgraduate.myongjigraduatebe.user.adaptor.in.web.signup;
 
 import javax.validation.Valid;
 
+import org.springframework.data.repository.query.Param;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import com.plzgraduate.myongjigraduatebe.core.meta.WebAdapter;
+import com.plzgraduate.myongjigraduatebe.user.application.port.in.check.AuthIdDuplicationResponse;
+import com.plzgraduate.myongjigraduatebe.user.application.port.in.check.CheckAuthIdDuplicationUseCase;
 import com.plzgraduate.myongjigraduatebe.user.application.port.in.signup.SignUpUseCase;
 
 import lombok.RequiredArgsConstructor;
@@ -17,9 +21,15 @@ import lombok.RequiredArgsConstructor;
 public class SignUpController {
 
 	private final SignUpUseCase signUpUseCase;
+	private final CheckAuthIdDuplicationUseCase checkAuthIdDuplicationUseCase;
 
 	@PostMapping("/sign-up")
 	public void signUp(@Valid @RequestBody SignUpRequest signUpRequest) {
 		signUpUseCase.signUp(signUpRequest.toCommand());
+	}
+
+	@GetMapping("/check-duplicate-auth-id")
+	public AuthIdDuplicationResponse checkAuthIdDuplication(@Param("authId") String authId) {
+		return checkAuthIdDuplicationUseCase.checkAuthIdDuplication(authId);
 	}
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/adaptor/in/web/signup/SignUpController.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/adaptor/in/web/signup/SignUpController.java
@@ -2,11 +2,11 @@ package com.plzgraduate.myongjigraduatebe.user.adaptor.in.web.signup;
 
 import javax.validation.Valid;
 
-import org.springframework.data.repository.query.Param;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import com.plzgraduate.myongjigraduatebe.core.meta.WebAdapter;
 import com.plzgraduate.myongjigraduatebe.user.application.port.in.check.AuthIdDuplicationResponse;
@@ -28,8 +28,8 @@ public class SignUpController {
 		signUpUseCase.signUp(signUpRequest.toCommand());
 	}
 
-	@GetMapping("/check-duplicate-auth-id")
-	public AuthIdDuplicationResponse checkAuthIdDuplication(@Param("authId") String authId) {
+	@GetMapping("/sign-up/check-duplicate-auth-id")
+	public AuthIdDuplicationResponse checkAuthIdDuplication(@RequestParam("auth-id") String authId) {
 		return checkAuthIdDuplicationUseCase.checkAuthIdDuplication(authId);
 	}
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/adaptor/in/web/signup/SignUpRequest.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/adaptor/in/web/signup/SignUpRequest.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class SignUpRequest {
 
-	@NotBlank(message = "아아디를 입력해주세요.")
+	@NotBlank(message = "아이디를 입력해주세요.")
 	@Size(min = 6, max = 20, message = "아이디는 6자에서 20자 사이여야합니다.")
 	private String authId;
 

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/application/port/in/check/AuthIdDuplicationResponse.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/application/port/in/check/AuthIdDuplicationResponse.java
@@ -1,0 +1,20 @@
+package com.plzgraduate.myongjigraduatebe.user.application.port.in.check;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AuthIdDuplicationResponse {
+
+	private String authId;
+
+	private boolean notDuplicated;
+
+	@Builder
+	private AuthIdDuplicationResponse(String authId, boolean notDuplicated) {
+		this.authId = authId;
+		this.notDuplicated = notDuplicated;
+	}
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/application/port/in/check/CheckAuthIdDuplicationUseCase.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/application/port/in/check/CheckAuthIdDuplicationUseCase.java
@@ -1,0 +1,6 @@
+package com.plzgraduate.myongjigraduatebe.user.application.port.in.check;
+
+public interface CheckAuthIdDuplicationUseCase {
+
+	AuthIdDuplicationResponse checkAuthIdDuplication(String authId);
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/application/service/check/CheckAuthIdDuplicationService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/application/service/check/CheckAuthIdDuplicationService.java
@@ -1,0 +1,26 @@
+package com.plzgraduate.myongjigraduatebe.user.application.service.check;
+
+import org.springframework.transaction.annotation.Transactional;
+
+import com.plzgraduate.myongjigraduatebe.core.meta.UseCase;
+import com.plzgraduate.myongjigraduatebe.user.application.port.in.check.AuthIdDuplicationResponse;
+import com.plzgraduate.myongjigraduatebe.user.application.port.in.check.CheckAuthIdDuplicationUseCase;
+import com.plzgraduate.myongjigraduatebe.user.application.port.out.CheckUserPort;
+
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CheckAuthIdDuplicationService implements CheckAuthIdDuplicationUseCase {
+
+	private final CheckUserPort checkUserPort;
+
+	@Override
+	public AuthIdDuplicationResponse checkAuthIdDuplication(String authId) {
+		boolean authIdDuplication = checkUserPort.checkDuplicateAuthId(authId);
+		return AuthIdDuplicationResponse.builder()
+			.authId(authId)
+			.notDuplicated(!authIdDuplication).build();
+	}
+}

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/user/adaptor/in/web/SignUpControllerTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/user/adaptor/in/web/SignUpControllerTest.java
@@ -1,6 +1,8 @@
 package com.plzgraduate.myongjigraduatebe.user.adaptor.in.web;
 
+import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -16,6 +18,8 @@ import org.springframework.test.web.servlet.ResultActions;
 import com.plzgraduate.myongjigraduatebe.support.WebAdaptorTestSupport;
 import com.plzgraduate.myongjigraduatebe.user.adaptor.in.web.signup.SignUpController;
 import com.plzgraduate.myongjigraduatebe.user.adaptor.in.web.signup.SignUpRequest;
+import com.plzgraduate.myongjigraduatebe.user.application.port.in.check.AuthIdDuplicationResponse;
+import com.plzgraduate.myongjigraduatebe.user.application.port.in.check.CheckAuthIdDuplicationUseCase;
 import com.plzgraduate.myongjigraduatebe.user.application.port.in.signup.SignUpUseCase;
 
 @WebMvcTest(controllers = SignUpController.class)
@@ -23,6 +27,8 @@ class SignUpControllerTest extends WebAdaptorTestSupport {
 
 	@MockBean
 	private SignUpUseCase signUpUseCase;
+	@MockBean
+	private CheckAuthIdDuplicationUseCase checkAuthIdDuplicationUseCase;
 
 	@DisplayName("회원가입을 진행한다.")
 	@Test
@@ -116,5 +122,27 @@ class SignUpControllerTest extends WebAdaptorTestSupport {
 			.andExpect(status().isBadRequest())
 			.andExpect(jsonPath("$.status").value(400))
 			.andExpect(jsonPath("$.message").value("비밀번호는 문자, 숫자, 기호가 1개 이상 포함되어야합니다."));
+	}
+
+	@DisplayName("로그인 아이디 중복 여부를 체크한다.")
+	@Test
+	void checkAuthIdDuplication() throws Exception {
+		//given
+		String authId = "testUserId";
+		boolean notDuplicated = true;
+		AuthIdDuplicationResponse authIdDuplicationResponse = AuthIdDuplicationResponse.builder()
+			.authId(authId)
+			.notDuplicated(notDuplicated).build();
+		given(checkAuthIdDuplicationUseCase.checkAuthIdDuplication(authId)).willReturn(authIdDuplicationResponse);
+
+		//when //then
+		mockMvc.perform(
+				get("/api/v1/users/check-duplicate-auth-id")
+					.param("authId", authId)
+			)
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.authId").value(authId))
+			.andExpect(jsonPath("$.notDuplicated").value(notDuplicated));
 	}
 }

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/user/adaptor/in/web/SignUpControllerTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/user/adaptor/in/web/SignUpControllerTest.java
@@ -135,10 +135,10 @@ class SignUpControllerTest extends WebAdaptorTestSupport {
 			.notDuplicated(notDuplicated).build();
 		given(checkAuthIdDuplicationUseCase.checkAuthIdDuplication(authId)).willReturn(authIdDuplicationResponse);
 
-		//when //then
+		//when //then`
 		mockMvc.perform(
-				get("/api/v1/users/check-duplicate-auth-id")
-					.param("authId", authId)
+				get("/api/v1/users/sign-up/check-duplicate-auth-id")
+					.param("auth-id", authId)
 			)
 			.andDo(print())
 			.andExpect(status().isOk())

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/user/adaptor/in/web/signup/SignUpControllerTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/user/adaptor/in/web/signup/SignUpControllerTest.java
@@ -1,4 +1,4 @@
-package com.plzgraduate.myongjigraduatebe.user.adaptor.in.web;
+package com.plzgraduate.myongjigraduatebe.user.adaptor.in.web.signup;
 
 import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -16,8 +16,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
 import com.plzgraduate.myongjigraduatebe.support.WebAdaptorTestSupport;
-import com.plzgraduate.myongjigraduatebe.user.adaptor.in.web.signup.SignUpController;
-import com.plzgraduate.myongjigraduatebe.user.adaptor.in.web.signup.SignUpRequest;
 import com.plzgraduate.myongjigraduatebe.user.application.port.in.check.AuthIdDuplicationResponse;
 import com.plzgraduate.myongjigraduatebe.user.application.port.in.check.CheckAuthIdDuplicationUseCase;
 import com.plzgraduate.myongjigraduatebe.user.application.port.in.signup.SignUpUseCase;

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/user/application/service/check/CheckAuthIdDuplicationServiceTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/user/application/service/check/CheckAuthIdDuplicationServiceTest.java
@@ -35,7 +35,7 @@ class CheckAuthIdDuplicationServiceTest {
 			authId);
 
 		//then
-		assertThat(authIdDuplicationResponse).extracting("authId", "isNotDuplicated")
+		assertThat(authIdDuplicationResponse).extracting("authId", "notDuplicated")
 			.contains(authId, !authIdDuplication);
 	}
 

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/user/application/service/check/CheckAuthIdDuplicationServiceTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/user/application/service/check/CheckAuthIdDuplicationServiceTest.java
@@ -1,0 +1,42 @@
+package com.plzgraduate.myongjigraduatebe.user.application.service.check;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.plzgraduate.myongjigraduatebe.user.application.port.in.check.AuthIdDuplicationResponse;
+import com.plzgraduate.myongjigraduatebe.user.application.port.out.CheckUserPort;
+
+@ExtendWith(MockitoExtension.class)
+class CheckAuthIdDuplicationServiceTest {
+
+	@Mock
+	private CheckUserPort checkUserPort;
+
+	@InjectMocks
+	private CheckAuthIdDuplicationService checkAuthIdDuplicationService;
+
+	@DisplayName("로그인 아이디의 중복 여부를 확인한다.")
+	@Test
+	void checkAuthIdDuplication() {
+	    //given
+		String authId = "testAuthId";
+		boolean authIdDuplication = true;
+		given(checkUserPort.checkDuplicateAuthId(authId)).willReturn(authIdDuplication);
+
+	    //when
+		AuthIdDuplicationResponse authIdDuplicationResponse = checkAuthIdDuplicationService.checkAuthIdDuplication(
+			authId);
+
+		//then
+		assertThat(authIdDuplicationResponse).extracting("authId", "isNotDuplicated")
+			.contains(authId, !authIdDuplication);
+	}
+
+}


### PR DESCRIPTION
## Issue
Close #183 

## ✅ 작업 내용
- 아이디 중복 체크 구현

## 🤔 고민 했던 부분
- 아이디 중복 체크 api의 컨트롤러를 따로 구현할지 아니면 회원가입 컨트롤러에 같이 둘지 고민했었습니다. 해당 기능이 회원가입 프로세스에서만 사용된다는 점 고려해 따로 분리하지 않고, SignUpController에 작성했습니다.

## 🔊 도움이 필요한 부분!!