### PR TITLE
오류 API 수정

### DIFF
--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/ChapelResult.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/ChapelResult.java
@@ -8,8 +8,6 @@ import lombok.Getter;
 @Getter
 public class ChapelResult {
 
-	public static int CHAPEL_CREDIT = 2;
-
 	private static final String CHAPEL_LECTURE_CODE = "KMA02101";
 	private static final int GRADUATION_COUNT = 4;
 
@@ -30,6 +28,10 @@ public class ChapelResult {
 
 	public void checkCompleted() {
 		isCompleted = takenCount >= GRADUATION_COUNT;
+	}
+
+	public int getTakenChapelCredit() {
+		return takenCount / 2;
 	}
 
 	private static int countTakenChapel(TakenLectureInventory takenLectureInventory) {

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/DetailCategoryResult.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/DetailCategoryResult.java
@@ -77,9 +77,11 @@ public class DetailCategoryResult {
 		if (leftCredit > 0) {
 			if (detailCategoryName.equals(MAJOR.getName())) {
 				freeElectiveLeftCredit = leftCredit;
+				takenCredits -= leftCredit;
 				return;
 			}
 			normalLeftCredit = leftCredit;
+			takenCredits -= leftCredit;
 		}
 	}
 

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/GraduationResult.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/GraduationResult.java
@@ -55,7 +55,6 @@ public class GraduationResult {
 		this.totalCredit = detailGraduationResults.stream()
 			.mapToInt(DetailGraduationResult::getTotalCredit)
 			.sum()
-			+ CHAPEL_CREDIT
 			+ normalCultureGraduationResult.getTotalCredit()
 			+ freeElectiveGraduationResult.getTotalCredit();
 

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/GraduationResult.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/GraduationResult.java
@@ -1,7 +1,5 @@
 package com.plzgraduate.myongjigraduatebe.graduation.domain.model;
 
-import static com.plzgraduate.myongjigraduatebe.graduation.domain.model.ChapelResult.*;
-
 import java.util.List;
 
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
@@ -63,7 +61,7 @@ public class GraduationResult {
 			.sum()
 			+ normalCultureGraduationResult.getTakenCredit()
 			+ freeElectiveGraduationResult.getTakenCredit()
-			+ (chapelResult.isCompleted() ? CHAPEL_CREDIT : 0);
+			+ chapelResult.getTakenChapelCredit();
 
 		boolean isAllDetailGraduationResultCompleted = detailGraduationResults.stream()
 			.allMatch(DetailGraduationResult::isCompleted);

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/basicacademicalculture/BusinessBasicAcademicalManager.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/basicacademicalculture/BusinessBasicAcademicalManager.java
@@ -17,9 +17,9 @@ import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureI
 public class BusinessBasicAcademicalManager implements BasicAcademicalManager {
 
 	private static final int TWENTY = 20;
-	private static final String BUSINESS_ADMINISTRATION = "경영";
-	private static final String MANAGEMENT_INFORMATION = "경영정보";
-	private static final String INTERNATIONAL_TRADE = "국제통상";
+	private static final String BUSINESS_ADMINISTRATION = "경영학과";
+	private static final String MANAGEMENT_INFORMATION = "경영정보학과";
+	private static final String INTERNATIONAL_TRADE = "국제통상학과";
 	private static final Set<Lecture> businessBefore20 = Set.of(
 		Lecture.of("KMD02114", "미시경제학원론", 3, 0, null),
 		Lecture.of("KMD02107", "경상통계학", 3, 0, null)

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/major/exception/OptionalMandatory.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/major/exception/OptionalMandatory.java
@@ -13,8 +13,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum OptionalMandatory {
-	ADMINISTRATIONS("행정", 2, Set.of()),
-	BUSINESS("경영", 4, Set.of(
+	ADMINISTRATIONS("행정학과", 2, Set.of()),
+	BUSINESS("경영학과", 4, Set.of(
 		Lecture.of("HBX01104", "회계원리", 3, 0, null),
 		Lecture.of("HBX01113", "인적자원관리", 3, 0, null),
 		Lecture.of("HBX01106", "마케팅원론", 3, 0, null),
@@ -22,7 +22,7 @@ public enum OptionalMandatory {
 		Lecture.of("HBX01114", "생산운영관리", 3, 1, null),
 		Lecture.of("HBX01143", "운영관리", 3, 0, null)
 	)),
-	INTERNATIONAL_TRADE("국제통상", 4, Set.of(
+	INTERNATIONAL_TRADE("국제통상학과", 4, Set.of(
 		Lecture.of("HBX01104", "회계원리", 3, 0, null),
 		Lecture.of("HBX01113", "인적자원관리", 3, 0, null),
 		Lecture.of("HBX01106", "마케팅원론", 3, 0, null),
@@ -30,7 +30,7 @@ public enum OptionalMandatory {
 		Lecture.of("HBX01114", "생산운영관리", 3, 1, null),
 		Lecture.of("HBX01143", "운영관리", 3, 0, null)
 	)),
-	MANAGEMENT_INFORMATION("경영정보", 3, Set.of());
+	MANAGEMENT_INFORMATION("경영정보학과", 3, Set.of());
 
 	private final String department;
 	private final int chooseNUmber;

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/major/exception/OptionalMandatoryHandler.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/major/exception/OptionalMandatoryHandler.java
@@ -15,10 +15,10 @@ public class OptionalMandatoryHandler implements MajorExceptionHandler {
 	private int removedMandatoryTotalCredit = 0;
 
 	public boolean isSupport(User user) {
-		if (user.getMajor().equals("경영정보") && user.getEntryYear() >= 19) {
+		if (user.getMajor().equals("경영정보학과") && user.getEntryYear() >= 19) {
 			return true;
 		}
-		return List.of("행정", "경영", "국제통상").contains(user.getMajor());
+		return List.of("행정학과", "경영학과", "국제통상학과").contains(user.getMajor());
 	}
 
 	@Override

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/major/exception/ReplaceMandatoryMajorHandler.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/major/exception/ReplaceMandatoryMajorHandler.java
@@ -23,7 +23,7 @@ public class ReplaceMandatoryMajorHandler implements MajorExceptionHandler {
 
 	@Override
 	public boolean isSupport(User user) {
-		return user.getMajor().equals("철학") && user.getEntryYear() <= 21;
+		return user.getMajor().equals("철학과") && user.getEntryYear() <= 21;
 	}
 
 	@Override

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/lecture/adapter/out/persistence/FindCommonCulturePersistenceAdapter.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/lecture/adapter/out/persistence/FindCommonCulturePersistenceAdapter.java
@@ -1,5 +1,7 @@
 package com.plzgraduate.myongjigraduatebe.lecture.adapter.out.persistence;
 
+import static com.plzgraduate.myongjigraduatebe.user.domain.model.EnglishLevel.*;
+
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -20,7 +22,29 @@ class FindCommonCulturePersistenceAdapter implements FindCommonCulturePort {
 
 	@Override
 	public Set<CommonCulture> findCommonCulture(User user) {
-		return commonCultureRepository.findAllByEntryYear(user.getEntryYear()).stream()
+		if (user.getEnglishLevel() == ENG12) {
+			return findEng12CommonCultures(user);
+		}
+		if (user.getEnglishLevel() == ENG34) {
+			return findEng34CommonCultures(user);
+		}
+		return findEngFreeCommonCultures(user);
+	}
+
+	private Set<CommonCulture> findEng12CommonCultures(User user) {
+		return commonCultureRepository.findEng12GraduationCommonCulturesByEntryYear(user.getEntryYear()).stream()
+			.map(lectureMapper::mapToCommonCultureModel)
+			.collect(Collectors.toSet());
+	}
+
+	private Set<CommonCulture> findEng34CommonCultures(User user) {
+		return commonCultureRepository.findEng34GraduationCommonCulturesByEntryYear(user.getEntryYear()).stream()
+			.map(lectureMapper::mapToCommonCultureModel)
+			.collect(Collectors.toSet());
+	}
+
+	private Set<CommonCulture> findEngFreeCommonCultures(User user) {
+		return commonCultureRepository.findEngFreeGraduationCommonCulturesByEntryYear(user.getEntryYear()).stream()
 			.map(lectureMapper::mapToCommonCultureModel)
 			.collect(Collectors.toSet());
 	}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/lecture/adapter/out/persistence/LectureMapper.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/lecture/adapter/out/persistence/LectureMapper.java
@@ -33,6 +33,7 @@ public class LectureMapper {
 		return CommonCulture.builder()
 			.lecture(
 				Lecture.builder()
+					.id(lectureJpaEntity.getId())
 					.lectureCode(lectureJpaEntity.getLectureCode())
 					.name(lectureJpaEntity.getName())
 					.credit(lectureJpaEntity.getCredit())
@@ -49,6 +50,7 @@ public class LectureMapper {
 		return CoreCulture.builder()
 			.lecture(
 				Lecture.builder()
+					.id(lectureJpaEntity.getId())
 					.lectureCode(lectureJpaEntity.getLectureCode())
 					.name(lectureJpaEntity.getName())
 					.credit(lectureJpaEntity.getCredit())
@@ -66,6 +68,7 @@ public class LectureMapper {
 		return BasicAcademicalCultureLecture.builder()
 			.lecture(
 				Lecture.builder()
+					.id(lectureJpaEntity.getId())
 					.lectureCode(lectureJpaEntity.getLectureCode())
 					.name(lectureJpaEntity.getName())
 					.credit(lectureJpaEntity.getCredit())
@@ -82,6 +85,7 @@ public class LectureMapper {
 		return MajorLecture.builder()
 			.lecture(
 				Lecture.builder()
+					.id(lectureJpaEntity.getId())
 					.lectureCode(lectureJpaEntity.getLectureCode())
 					.name(lectureJpaEntity.getName())
 					.credit(lectureJpaEntity.getCredit())

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/lecture/adapter/out/persistence/repository/CommonCultureRepository.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/lecture/adapter/out/persistence/repository/CommonCultureRepository.java
@@ -10,10 +10,10 @@ import com.plzgraduate.myongjigraduatebe.lecture.adapter.out.persistence.entity.
 
 public interface CommonCultureRepository extends JpaRepository<CommonCultureJpaEntity, Long> {
 
-	@Query("select cc from CommonCultureJpaEntity cc join fetch cc.lectureJpaEntity where cc.startEntryYear <= :entryYear and cc.endEntryYear >= :entryYear and cc.lectureJpaEntity.lectureCode not in ('KMA02108', 'KMA02109', 'KMA02125', 'KMA02126')")
+	@Query("select cc from CommonCultureJpaEntity cc join fetch cc.lectureJpaEntity where cc.startEntryYear <= :entryYear and cc.endEntryYear >= :entryYear and cc.lectureJpaEntity.lectureCode not in ('KMA02123', 'KMA02124', 'KMA02125', 'KMA02126')")
 	List<CommonCultureJpaEntity> findEng12GraduationCommonCulturesByEntryYear(@Param("entryYear") int entryYear);
 
-	@Query("select cc from CommonCultureJpaEntity cc join fetch cc.lectureJpaEntity where cc.startEntryYear <= :entryYear and cc.endEntryYear >= :entryYear and cc.lectureJpaEntity.lectureCode not in ('KMA02106', 'KMA02107', 'KMA02123', 'KMA02124')")
+	@Query("select cc from CommonCultureJpaEntity cc join fetch cc.lectureJpaEntity where cc.startEntryYear <= :entryYear and cc.endEntryYear >= :entryYear and cc.lectureJpaEntity.lectureCode not in ('KMA02106', 'KMA02107', 'KMA02108', 'KMA02109')")
 	List<CommonCultureJpaEntity> findEng34GraduationCommonCulturesByEntryYear(@Param("entryYear") int entryYear);
 
 	@Query("select cc from CommonCultureJpaEntity cc join fetch cc.lectureJpaEntity where cc.startEntryYear <= :entryYear and cc.endEntryYear >= :entryYear and cc.commonCultureCategory != 'ENGLISH'")

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/lecture/adapter/out/persistence/repository/CommonCultureRepository.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/lecture/adapter/out/persistence/repository/CommonCultureRepository.java
@@ -10,6 +10,12 @@ import com.plzgraduate.myongjigraduatebe.lecture.adapter.out.persistence.entity.
 
 public interface CommonCultureRepository extends JpaRepository<CommonCultureJpaEntity, Long> {
 
-	@Query("select cc from CommonCultureJpaEntity cc join fetch cc.lectureJpaEntity where cc.startEntryYear <= :entryYear and cc.endEntryYear >= :entryYear")
-	List<CommonCultureJpaEntity> findAllByEntryYear(@Param("entryYear") int entryYear);
+	@Query("select cc from CommonCultureJpaEntity cc join fetch cc.lectureJpaEntity where cc.startEntryYear <= :entryYear and cc.endEntryYear >= :entryYear and cc.lectureJpaEntity.lectureCode not in ('KMA02108', 'KMA02109', 'KMA02125', 'KMA02126')")
+	List<CommonCultureJpaEntity> findEng12GraduationCommonCulturesByEntryYear(@Param("entryYear") int entryYear);
+
+	@Query("select cc from CommonCultureJpaEntity cc join fetch cc.lectureJpaEntity where cc.startEntryYear <= :entryYear and cc.endEntryYear >= :entryYear and cc.lectureJpaEntity.lectureCode not in ('KMA02106', 'KMA02107', 'KMA02123', 'KMA02124')")
+	List<CommonCultureJpaEntity> findEng34GraduationCommonCulturesByEntryYear(@Param("entryYear") int entryYear);
+
+	@Query("select cc from CommonCultureJpaEntity cc join fetch cc.lectureJpaEntity where cc.startEntryYear <= :entryYear and cc.endEntryYear >= :entryYear and cc.commonCultureCategory != 'ENGLISH'")
+	List<CommonCultureJpaEntity> findEngFreeGraduationCommonCulturesByEntryYear(@Param("entryYear") int entryYear);
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/adaptor/out/persistence/ParsingTextHistoryAdaptor.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/adaptor/out/persistence/ParsingTextHistoryAdaptor.java
@@ -1,19 +1,26 @@
 package com.plzgraduate.myongjigraduatebe.parsing.adaptor.out.persistence;
 
 import com.plzgraduate.myongjigraduatebe.core.meta.PersistenceAdapter;
+import com.plzgraduate.myongjigraduatebe.parsing.application.port.out.DeleteParsingTextHistoryPort;
 import com.plzgraduate.myongjigraduatebe.parsing.application.port.out.SaveParsingTextHistoryPort;
 import com.plzgraduate.myongjigraduatebe.parsing.domain.ParsingTextHistory;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
 
 import lombok.RequiredArgsConstructor;
 
 @PersistenceAdapter
 @RequiredArgsConstructor
-class ParsingTextHistoryAdaptor implements SaveParsingTextHistoryPort {
+class ParsingTextHistoryAdaptor implements SaveParsingTextHistoryPort, DeleteParsingTextHistoryPort {
 
 	private final ParsingTextRepository parsingTextRepository;
 	private final ParsingTextHistoryMapper parsingTextHistoryMapper;
 	@Override
 	public void saveParsingTextHistory(ParsingTextHistory parsingTextHistory) {
 		parsingTextRepository.save(parsingTextHistoryMapper.mapToJpaEntity(parsingTextHistory));
+	}
+
+	@Override
+	public void deleteUserParsingTextHistory(User user) {
+		parsingTextRepository.deleteAllByUser(parsingTextHistoryMapper.mapToUserJpaEntity(user));
 	}
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/adaptor/out/persistence/ParsingTextHistoryMapper.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/adaptor/out/persistence/ParsingTextHistoryMapper.java
@@ -19,7 +19,7 @@ class ParsingTextHistoryMapper {
 			.build();
 	}
 
-	private UserJpaEntity mapToUserJpaEntity(User user) {
+	UserJpaEntity mapToUserJpaEntity(User user) {
 
 		return UserJpaEntity.builder()
 			.id(user.getId())

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/adaptor/out/persistence/ParsingTextRepository.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/adaptor/out/persistence/ParsingTextRepository.java
@@ -2,6 +2,10 @@ package com.plzgraduate.myongjigraduatebe.parsing.adaptor.out.persistence;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.plzgraduate.myongjigraduatebe.user.adaptor.out.persistence.UserJpaEntity;
+
 public interface ParsingTextRepository extends JpaRepository<ParsingTextHistoryJpaEntity, Long> {
+
+	void deleteAllByUser(UserJpaEntity user);
 
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/application/port/out/DeleteParsingTextHistoryPort.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/application/port/out/DeleteParsingTextHistoryPort.java
@@ -1,0 +1,8 @@
+package com.plzgraduate.myongjigraduatebe.parsing.application.port.out;
+
+import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
+
+public interface DeleteParsingTextHistoryPort {
+
+	void deleteUserParsingTextHistory(User user);
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/application/service/withdraw/WithDrawUserService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/application/service/withdraw/WithDrawUserService.java
@@ -3,6 +3,7 @@ package com.plzgraduate.myongjigraduatebe.user.application.service.withdraw;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.plzgraduate.myongjigraduatebe.core.meta.UseCase;
+import com.plzgraduate.myongjigraduatebe.parsing.application.port.out.DeleteParsingTextHistoryPort;
 import com.plzgraduate.myongjigraduatebe.takenlecture.application.port.in.delete.DeleteTakenLectureByUserUseCase;
 import com.plzgraduate.myongjigraduatebe.user.application.port.in.find.FindUserUseCase;
 import com.plzgraduate.myongjigraduatebe.user.application.port.in.withdraw.WithDrawUserUseCase;
@@ -18,12 +19,14 @@ class WithDrawUserService implements WithDrawUserUseCase {
 
 	private final FindUserUseCase findUserUseCase;
 	private final DeleteTakenLectureByUserUseCase deleteTakenLectureByUserUseCase;
+	private final DeleteParsingTextHistoryPort deleteParsingTextHistoryPort;
 	private final DeleteUserPort deleteUserPort;
 
 	@Override
 	public void withDraw(Long userId) {
 		User user = findUserUseCase.findUserById(userId);
 		deleteTakenLectureByUserUseCase.deleteAllTakenLecturesByUser(user);
+		deleteParsingTextHistoryPort.deleteUserParsingTextHistory(user);
 		deleteUserPort.deleteUser(user);
 	}
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/domain/model/College.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/domain/model/College.java
@@ -10,11 +10,12 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum College {
 
-	HUMANITIES("인문대", List.of("국어국문", "문예창작", "영어영문", "중어중문", "일어일문", "문헌정보", "사학", "아랍지역", "사학", "철학")),
-	SOCIAL_SCIENCE("사회과학대", List.of("행정", "경제", "정치외교", "디지털미디어", "아동", "청소년지도", "사회복지")),
-	BUSINESS("경영대", List.of("경영", "경영정보", "국제통상")),
-	LAW("법대", List.of("법학")),
-	ICT("ICT융합대", List.of("디지털콘텐츠디자인", "응용소프트웨어", "데이터테크놀로지"));
+	HUMANITIES("인문대",
+		List.of("국어국문학과", "문예창작학과", "영어영문학과", "중어중문학과", "일어일문학과", "문헌정보학과", "미술사학과", "아랍지역학과", "사학과", "철학과")),
+	SOCIAL_SCIENCE("사회과학대", List.of("행정학과", "경제학과", "정치외교학과", "디지털미디어학과", "아동학과", "청소년지도학과")),
+	BUSINESS("경영대", List.of("경영학과", "경영정보학과", "국제통상학과")),
+	LAW("법대", List.of("법학과")),
+	ICT("ICT융합대", List.of("디지털콘텐츠디자인학과", "응용소프트웨어전공", "데이터테크놀로지전공"));
 
 	private final String text;
 	private final List<String> holdingMajors;

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/fixture/MajorFixture.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/fixture/MajorFixture.java
@@ -10,8 +10,8 @@ import com.plzgraduate.myongjigraduatebe.lecture.domain.model.MajorLecture;
 public class MajorFixture {
 
 	public static final Map<String, Lecture> mockLectureMap = LectureFixture.getMockLectureMap();
-	private static final String 국제통상학과 = "국제통상";
-	private static final String 데이터테크놀로지전공 = "데이터테크놀로지";
+	private static final String 국제통상학과 = "국제통상학과";
+	private static final String 데이터테크놀로지전공 = "데이터테크놀로지전공";
 
 
 	public static Set<MajorLecture> 국제통상_전공() {

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/fixture/UserFixture.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/fixture/UserFixture.java
@@ -65,6 +65,11 @@ public class UserFixture {
 			StudentCategory.NORMAL);
 	}
 
+	public static User 데이테크놀로지학과_16학번_Eng34() {
+		return createUser("mj1001", "1234", EnglishLevel.ENG34, "정데테", "60161666", 16, "데이터테크놀로지전공", null,
+			StudentCategory.NORMAL);
+	}
+
 	public static User 데이테크놀로지학과_18학번() {
 		return createUser("mj1003", "1234", EnglishLevel.ENG12, "정데테", "60181666", 18, "데이터테크놀로지전공", null,
 			StudentCategory.NORMAL);

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/fixture/UserFixture.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/fixture/UserFixture.java
@@ -7,96 +7,96 @@ import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
 public class UserFixture {
 
 	public static User 영문학과_16학번() {
-		return createUser("mj01", "1234", EnglishLevel.ENG12, "김영문", "60161001", 16, "영어영문", null,
+		return createUser("mj01", "1234", EnglishLevel.ENG12, "김영문", "60161001", 16, "영어영문학과", null,
 			StudentCategory.NORMAL);
 	}
 
 	public static User 영문학과_18학번() {
-		return createUser("mj01", "1234", EnglishLevel.ENG12, "김영문", "60181001", 18, "영어영문", null,
+		return createUser("mj01", "1234", EnglishLevel.ENG12, "김영문", "60181001", 18, "영어영문학과", null,
 			StudentCategory.NORMAL);
 	}
 
 	public static User 철학과_20학번() {
-		return createUser("mj51", "1234", EnglishLevel.ENG34, "김철학", "60201011", 20, "철학", null,
+		return createUser("mj51", "1234", EnglishLevel.ENG34, "김철학", "60201011", 20, "철학학과", null,
 			StudentCategory.NORMAL);
 	}
 
 	public static User 행정학과_21학번() {
-		return createUser("mj12", "1234", EnglishLevel.ENG34, "김행정", "60211012", 21, "행정", null,
+		return createUser("mj12", "1234", EnglishLevel.ENG34, "김행정", "60211012", 21, "행정학과", null,
 			StudentCategory.NORMAL);
 	}
 
 	public static User 경영학과_19학번_ENG12() {
-		return createUser("mj21", "1234", EnglishLevel.ENG12, "김경영", "60191021", 19, "경영", null,
+		return createUser("mj21", "1234", EnglishLevel.ENG12, "김경영", "60191021", 19, "경영학과", null,
 			StudentCategory.NORMAL);
 	}
 
 	public static User 경영학과_19학번_ENG34() {
-		return createUser("mj21", "1234", EnglishLevel.ENG34, "김경영", "60191021", 19, "경영", null,
+		return createUser("mj21", "1234", EnglishLevel.ENG34, "김경영", "60191021", 19, "경영학과", null,
 			StudentCategory.NORMAL);
 	}
 
 	public static User 경영학과_19학번_ENG34_복수전공() {
-		return createUser("mj21", "1234", EnglishLevel.ENG34, "김경영", "60191021", 19, "경영", "국제통상",
+		return createUser("mj21", "1234", EnglishLevel.ENG34, "김경영", "60191021", 19, "경영학과", "국제통상학과",
 			StudentCategory.NORMAL);
 	}
 
 	public static User 경영학과_19학번_영어_면제() {
-		return createUser("mj21", "1234", EnglishLevel.FREE, "김경영", "60191021", 19, "경영", null, StudentCategory.NORMAL);
+		return createUser("mj21", "1234", EnglishLevel.FREE, "김경영", "60191021", 19, "경영학과", null, StudentCategory.NORMAL);
 	}
 
 	public static User 경영학과_22학번() {
-		return createUser("mj22", "1234", EnglishLevel.ENG34, "김경영", "60221022", 22, "경영", null,
+		return createUser("mj22", "1234", EnglishLevel.ENG34, "김경영", "60221022", 22, "경영학과", null,
 			StudentCategory.NORMAL);
 	}
 
 	public static User 경영학과_23학번() {
-		return createUser("mj22", "1234", EnglishLevel.ENG34, "김경영", "60231022", 23, "경영", null,
+		return createUser("mj22", "1234", EnglishLevel.ENG34, "김경영", "60231022", 23, "경영학과", null,
 			StudentCategory.NORMAL);
 	}
 
 	public static User 국제통상학과_19학번() {
-		return createUser("mj31", "1234", EnglishLevel.ENG34, "김국통", "60192021", 19, "국제통상", null,
+		return createUser("mj31", "1234", EnglishLevel.ENG34, "김국통", "60192021", 19, "국제통상학과", null,
 			StudentCategory.NORMAL);
 	}
 
 	public static User 데이테크놀로지학과_16학번() {
-		return createUser("mj1001", "1234", EnglishLevel.ENG12, "정데테", "60161666", 16, "데이터테크놀로지", null,
+		return createUser("mj1001", "1234", EnglishLevel.ENG12, "정데테", "60161666", 16, "데이터테크놀로지전공", null,
 			StudentCategory.NORMAL);
 	}
 
 	public static User 데이테크놀로지학과_18학번() {
-		return createUser("mj1003", "1234", EnglishLevel.ENG12, "정데테", "60181666", 18, "데이터테크놀로지", null,
+		return createUser("mj1003", "1234", EnglishLevel.ENG12, "정데테", "60181666", 18, "데이터테크놀로지전공", null,
 			StudentCategory.NORMAL);
 	}
 
 	public static User 응용소프트웨어학과_17학번() {
-		return createUser("mj22", "1234", EnglishLevel.ENG34, "김응용", "60171022", 17, "응용소프트웨어", null,
+		return createUser("mj22", "1234", EnglishLevel.ENG34, "김응용", "60171022", 17, "응용소프트웨어전공", null,
 			StudentCategory.NORMAL);
 	}
 
 	public static User 응용소프트웨어학과_19학번() {
-		return createUser("mj22", "1234", EnglishLevel.ENG34, "김응용", "60191022", 19, "응용소프트웨어", null,
+		return createUser("mj22", "1234", EnglishLevel.ENG34, "김응용", "60191022", 19, "응용소프트웨어전공", null,
 			StudentCategory.NORMAL);
 	}
 
 	public static User 응용소프트웨어학과_19학번_영어_면제() {
-		return createUser("mj22", "1234", EnglishLevel.FREE, "김응용", "60191022", 19, "응용소프트웨어", null,
+		return createUser("mj22", "1234", EnglishLevel.FREE, "김응용", "60191022", 19, "응용소프트웨어전공", null,
 			StudentCategory.NORMAL);
 	}
 
 	public static User 데이터테크놀로지학과_19학번() {
-		return createUser("mj22", "1234", EnglishLevel.ENG34, "김응용", "60191022", 19, "데이터테크놀로지", null,
+		return createUser("mj22", "1234", EnglishLevel.ENG34, "김응용", "60191022", 19, "데이터테크놀로지전공", null,
 			StudentCategory.NORMAL);
 	}
 
 	public static User 디지털콘텐츠디자인학과_19학번() {
-		return createUser("mj22", "1234", EnglishLevel.ENG34, "김응용", "60191022", 19, "디지털콘텐츠디자인", null,
+		return createUser("mj22", "1234", EnglishLevel.ENG34, "김응용", "60191022", 19, "디지털콘텐츠디자인학과", null,
 			StudentCategory.NORMAL);
 	}
 
 	public static User 디지털콘텐츠디자인학과_23학번() {
-		return createUser("mj22", "1234", EnglishLevel.ENG34, "김응용", "60231022", 23, "디지털콘텐츠디자인", null,
+		return createUser("mj22", "1234", EnglishLevel.ENG34, "김응용", "60231022", 23, "디지털콘텐츠디자인학과", null,
 			StudentCategory.NORMAL);
 	}
 

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/adpater/in/web/CalculateGraduationControllerTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/adpater/in/web/CalculateGraduationControllerTest.java
@@ -1,0 +1,64 @@
+package com.plzgraduate.myongjigraduatebe.graduation.adpater.in.web;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import com.plzgraduate.myongjigraduatebe.graduation.application.port.in.CalculateGraduationUseCase;
+import com.plzgraduate.myongjigraduatebe.graduation.application.port.in.response.BasicInfoResponse;
+import com.plzgraduate.myongjigraduatebe.graduation.application.port.in.response.ChapelResultResponse;
+import com.plzgraduate.myongjigraduatebe.graduation.application.port.in.response.DetailGraduationResultResponse;
+import com.plzgraduate.myongjigraduatebe.graduation.application.port.in.response.GraduationResponse;
+import com.plzgraduate.myongjigraduatebe.graduation.application.port.in.response.RestResultResponse;
+import com.plzgraduate.myongjigraduatebe.support.WebAdaptorTestSupport;
+import com.plzgraduate.myongjigraduatebe.support.WithMockAuthenticationUser;
+
+@WebMvcTest(controllers = CalculateGraduationController.class)
+class CalculateGraduationControllerTest extends WebAdaptorTestSupport {
+
+	@MockBean
+	private CalculateGraduationUseCase calculateGraduationUseCase;
+
+	@WithMockAuthenticationUser
+	@DisplayName("유저의 졸업 결과를 계산한다.")
+	@Test
+	void calculate() throws Exception {
+	    ///given
+		Long userId = 1L;
+		GraduationResponse response = GraduationResponse.builder()
+			.basicInfo(BasicInfoResponse.builder().build())
+			.chapelResult(ChapelResultResponse.builder().build())
+			.commonCulture(DetailGraduationResultResponse.builder().build())
+			.coreCulture(DetailGraduationResultResponse.builder().build())
+			.basicAcademicalCulture(DetailGraduationResultResponse.builder().build())
+			.major(DetailGraduationResultResponse.builder().build())
+			.normalCulture(RestResultResponse.builder().build())
+			.freeElective(RestResultResponse.builder().build())
+			.graduated(true).build();
+		given(calculateGraduationUseCase.calculateGraduation(userId)).willReturn(response);
+
+		//when //then
+		mockMvc.perform(
+			get("/api/v1/graduation/result")
+				.with(csrf()))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.basicInfo").exists())
+			.andExpect(jsonPath("$.chapelResult").exists())
+			.andExpect(jsonPath("$.commonCulture").exists())
+			.andExpect(jsonPath("$.coreCulture").exists())
+			.andExpect(jsonPath("$.basicAcademicalCulture").exists())
+			.andExpect(jsonPath("$.major").exists())
+			.andExpect(jsonPath("$.normalCulture").exists())
+			.andExpect(jsonPath("$.freeElective").exists())
+			.andExpect(jsonPath("$.graduated").isBoolean());
+	}
+}

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/ChapelResultTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/ChapelResultTest.java
@@ -1,6 +1,6 @@
 package com.plzgraduate.myongjigraduatebe.graduation.domain.model;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashSet;
 import java.util.Map;
@@ -8,6 +8,8 @@ import java.util.Set;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import com.plzgraduate.myongjigraduatebe.fixture.LectureFixture;
 import com.plzgraduate.myongjigraduatebe.fixture.UserFixture;
@@ -60,6 +62,21 @@ class ChapelResultTest {
 
 	    //then
 		assertThat(chapelResult.isCompleted()).isFalse();
+	}
+
+	@DisplayName("채플 수강 횟수에 따른 학점을 반환한다.(2회당 1점)")
+	@ParameterizedTest
+	@ValueSource(ints = {1, 2, 3, 4})
+	void getTakenChapelCredit(int takenCount) {
+	    //given
+		ChapelResult chapelResult = ChapelResult.builder()
+			.takenCount(takenCount).build();
+
+		//when
+		int takenChapelCredit = chapelResult.getTakenChapelCredit();
+
+		//then
+		assertThat(takenChapelCredit).isEqualTo(takenCount / 2);
 	}
 
 }

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/GraduationResultTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/GraduationResultTest.java
@@ -107,9 +107,9 @@ class GraduationResultTest {
 		//then
 		assertThat(graduationResult.isGraduated()).isTrue();
 		assertThat(graduationResult.getTotalCredit()).isEqualTo(
-			2 + detailCategoryTotalCredit + normalCultureTotalCredit + freeElectiveTotalCredit);
+			detailCategoryTotalCredit + normalCultureTotalCredit + freeElectiveTotalCredit);
 		assertThat(graduationResult.getTotalCredit()).isEqualTo(
-			2 + detailCategoryTakenCredit + normalCultureTakenCredit + freeElectiveTakenCredit);
+			detailCategoryTakenCredit + normalCultureTakenCredit + freeElectiveTakenCredit);
 	}
 
 	@DisplayName("채플 졸업 결과, 모든 세부 졸업 결과, 일반교양 졸업 결과, 자유선택 졸업 결과 중 하나라도 미이수일 시 전체 졸업 결과가 미이수이다.")

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/basicacademicalculture/DefaultBasicAcademicalManagerTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/basicacademicalculture/DefaultBasicAcademicalManagerTest.java
@@ -55,11 +55,11 @@ class DefaultBasicAcademicalManagerTest {
 			//then
 			assertThat(detailGraduationResult)
 				.extracting("categoryName", "isCompleted", "totalCredit", "takenCredit")
-				.contains("학문기초교양", true, 12, 15);
+				.contains("학문기초교양", true, 12, 12);
 
 			assertThat(detailCategoryResult)
 				.extracting("detailCategoryName", "isCompleted", "totalCredits", "takenCredits")
-				.contains("학문기초교양", true, 12, 15);
+				.contains("학문기초교양", true, 12, 12);
 
 			assertThat(detailCategoryResult.getTakenLectures()).hasSize(5);
 			assertThat(detailCategoryResult.getHaveToLectures()).isEmpty();

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/major/DataTechnologyMajorTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/major/DataTechnologyMajorTest.java
@@ -77,7 +77,7 @@ class DataTechnologyMajorTest {
 		//then
 		assertThat(detailGraduationResult)
 			.extracting("isCompleted", "totalCredit", "takenCredit")
-			.contains(true, 70, 71);
+			.contains(true, 70, 70);
 		assertThat(mandatoryDetailCategory)
 			.extracting("isCompleted", "isSatisfiedMandatory", "totalCredits", "takenCredits")
 			.contains(true, true, 36, 36);
@@ -85,7 +85,7 @@ class DataTechnologyMajorTest {
 		assertThat(mandatoryDetailCategory.getHaveToLectures()).isEmpty();
 		assertThat(electiveDetailCategory)
 			.extracting("isCompleted", "totalCredits", "takenCredits")
-			.contains(true, 34, 35);
+			.contains(true, 34, 34);
 		assertThat(electiveDetailCategory.getTakenLectures()).hasSize(12);
 		assertThat(electiveDetailCategory.getHaveToLectures()).isEmpty();
 	}

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/major/InternationTradeMajorTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/major/InternationTradeMajorTest.java
@@ -136,7 +136,7 @@ class InternationTradeMajorTest {
 		assertThat(mandatoryDetailCategory.getHaveToLectures()).hasSize(1);
 		assertThat(electiveDetailCategory)
 			.extracting("isCompleted", "totalCredits", "takenCredits")
-			.contains(true, 42, 45);
+			.contains(true, 42, 42);
 		assertThat(electiveDetailCategory.getTakenLectures()).hasSize(15);
 		assertThat(electiveDetailCategory.getHaveToLectures()).isEmpty();
 	}
@@ -192,7 +192,7 @@ class InternationTradeMajorTest {
 		assertThat(mandatoryDetailCategory.getHaveToLectures()).hasSize(2);
 		assertThat(electiveDetailCategory)
 			.extracting("isCompleted", "totalCredits", "takenCredits")
-			.contains(true, 42, 45);
+			.contains(true, 42, 42);
 		assertThat(electiveDetailCategory.getTakenLectures()).hasSize(15);
 		assertThat(electiveDetailCategory.getHaveToLectures()).isEmpty();
 	}

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/lecture/adapter/out/persistence/CommonCultureRepositoryTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/lecture/adapter/out/persistence/CommonCultureRepositoryTest.java
@@ -20,10 +20,10 @@ class CommonCultureRepositoryTest extends PersistenceTestSupport {
 
 	private static final String ENGLISH1_CODE = "KMA02106";
 	private static final String ENGLISH2_CODE = "KMA02107";
-	private static final String ENGLISH3_CODE = "KMA02108";
-	private static final String ENGLISH4_CODE = "KMA02109";
-	private static final String ENGLISH_CONVERSATION1_CODE = "KMA02123";
-	private static final String ENGLISH_CONVERSATION2_CODE = "KMA02124";
+	private static final String ENGLISH_CONVERSATION1_CODE = "KMA02108";
+	private static final String ENGLISH_CONVERSATION2_CODE = "KMA02109";
+	private static final String ENGLISH3_CODE = "KMA02123";
+	private static final String ENGLISH4_CODE = "KMA02124";
 	private static final String ENGLISH_CONVERSATION3_CODE = "KMA02125";
 	private static final String ENGLISH_CONVERSATION4_CODE = "KMA02126";
 

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/lecture/adapter/out/persistence/CommonCultureRepositoryTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/lecture/adapter/out/persistence/CommonCultureRepositoryTest.java
@@ -3,6 +3,7 @@ package com.plzgraduate.myongjigraduatebe.lecture.adapter.out.persistence;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -17,50 +18,134 @@ import com.plzgraduate.myongjigraduatebe.support.PersistenceTestSupport;
 
 class CommonCultureRepositoryTest extends PersistenceTestSupport {
 
+	private static final String ENGLISH1_CODE = "KMA02106";
+	private static final String ENGLISH2_CODE = "KMA02107";
+	private static final String ENGLISH3_CODE = "KMA02108";
+	private static final String ENGLISH4_CODE = "KMA02109";
+	private static final String ENGLISH_CONVERSATION1_CODE = "KMA02123";
+	private static final String ENGLISH_CONVERSATION2_CODE = "KMA02124";
+	private static final String ENGLISH_CONVERSATION3_CODE = "KMA02125";
+	private static final String ENGLISH_CONVERSATION4_CODE = "KMA02126";
+
+
 	@Autowired
 	private LectureRepository lectureRepository;
 	@Autowired
 	private CommonCultureRepository commonCultureRepository;
 
-	@DisplayName("유저의 입학년도가 적용 시작 년도, 적용 마감 년도 사이에 속하는 공통 교양 과목을 조회한다.")
+	@DisplayName("ENG12: 유저의 입학년도가 적용 시작 년도, 적용 마감 년도 사이에 속하는 공통 교양 과목을 조회한다.")
 	@ParameterizedTest
 	@ValueSource(ints = {16, 18, 20, 23})
-	void findAllByEntryYear(int entryYears) {
+	void findEng12AllByEntryYear(int entryYears) {
 		//given
-		LectureJpaEntity lectureJpaEntity = LectureJpaEntity.builder()
-			.lectureCode("test")
-			.build();
-		lectureRepository.save(lectureJpaEntity);
-
-		CommonCultureJpaEntity commonCultureJpaEntityA = CommonCultureJpaEntity.builder()
-			.lectureJpaEntity(lectureJpaEntity)
-			.startEntryYear(16)
-			.endEntryYear(17).build();
-		CommonCultureJpaEntity commonCultureJpaEntityB = CommonCultureJpaEntity.builder()
-			.lectureJpaEntity(lectureJpaEntity)
-			.startEntryYear(18)
-			.endEntryYear(19).build();
-		CommonCultureJpaEntity commonCultureJpaEntityC = CommonCultureJpaEntity.builder()
-			.lectureJpaEntity(lectureJpaEntity)
-			.startEntryYear(20)
-			.endEntryYear(22).build();
-		CommonCultureJpaEntity commonCultureJpaEntityD = CommonCultureJpaEntity.builder()
-			.lectureJpaEntity(lectureJpaEntity)
-			.startEntryYear(23)
-			.endEntryYear(99).build();
-
-		commonCultureRepository.saveAll(
-			List.of(commonCultureJpaEntityA, commonCultureJpaEntityB, commonCultureJpaEntityC,
-				commonCultureJpaEntityD));
+		saveEnglishLectures();
 
 		//when
-		List<CommonCultureJpaEntity> commonCultureGraduationLectures = commonCultureRepository.findAllByEntryYear(
-			entryYears);
+		List<CommonCultureJpaEntity> commonCultureGraduationLectures =
+			commonCultureRepository.findEng12GraduationCommonCulturesByEntryYear(entryYears);
 
 		//then
-		assertThat(commonCultureGraduationLectures).hasSize(1)
+		assertThat(commonCultureGraduationLectures).hasSize(4)
 			.extracting("startEntryYear")
 			.contains(entryYears);
 
+		List<String> lectureCodes = commonCultureGraduationLectures.stream()
+			.map(commonCultureJpaEntity -> commonCultureJpaEntity.getLectureJpaEntity().getLectureCode())
+			.collect(Collectors.toList());
+		assertThat(lectureCodes).doesNotContain(ENGLISH3_CODE);
+		assertThat(lectureCodes).doesNotContain(ENGLISH4_CODE);
+		assertThat(lectureCodes).doesNotContain(ENGLISH_CONVERSATION3_CODE);
+		assertThat(lectureCodes).doesNotContain(ENGLISH_CONVERSATION4_CODE);
+	}
+
+	@DisplayName("ENG34: 유저의 입학년도가 적용 시작 년도, 적용 마감 년도 사이에 속하는 공통 교양 과목을 조회한다.")
+	@ParameterizedTest
+	@ValueSource(ints = {16, 18, 20, 23})
+	void findEng34AllAllByEntryYear(int entryYears) {
+		//given
+		saveEnglishLectures();
+
+		//when
+		List<CommonCultureJpaEntity> commonCultureGraduationLectures =
+			commonCultureRepository.findEng34GraduationCommonCulturesByEntryYear(entryYears);
+
+		//then
+		assertThat(commonCultureGraduationLectures).hasSize(4)
+			.extracting("startEntryYear")
+			.contains(entryYears);
+
+		List<String> lectureCodes = commonCultureGraduationLectures.stream()
+			.map(commonCultureJpaEntity -> commonCultureJpaEntity.getLectureJpaEntity().getLectureCode())
+			.collect(Collectors.toList());
+		assertThat(lectureCodes).doesNotContain(ENGLISH1_CODE);
+		assertThat(lectureCodes).doesNotContain(ENGLISH2_CODE);
+		assertThat(lectureCodes).doesNotContain(ENGLISH_CONVERSATION1_CODE);
+		assertThat(lectureCodes).doesNotContain(ENGLISH_CONVERSATION2_CODE);
+	}
+
+	@DisplayName("ENGFREE: 유저의 입학년도가 적용 시작 년도, 적용 마감 년도 사이에 속하는 공통 교양 과목을 조회한다.")
+	@ParameterizedTest
+	@ValueSource(ints = {16, 18, 20, 23})
+	void findEngFreeAllAllByEntryYear(int entryYears) {
+		//given
+		saveEnglishLectures();
+
+		//when
+		List<CommonCultureJpaEntity> commonCultureGraduationLectures =
+			commonCultureRepository.findEngFreeGraduationCommonCulturesByEntryYear(entryYears);
+
+		//then
+		assertThat(commonCultureGraduationLectures).hasSize(0);
+	}
+
+	private void saveEnglishLectures() {
+		LectureJpaEntity 영어1 = LectureJpaEntity.builder()
+			.lectureCode(ENGLISH1_CODE)
+			.build();
+		LectureJpaEntity 영어2 = LectureJpaEntity.builder()
+			.lectureCode(ENGLISH2_CODE)
+			.build();
+		LectureJpaEntity 영어3 = LectureJpaEntity.builder()
+			.lectureCode(ENGLISH3_CODE)
+			.build();
+		LectureJpaEntity 영어4 = LectureJpaEntity.builder()
+			.lectureCode(ENGLISH4_CODE)
+			.build();
+		LectureJpaEntity 영어회화1 = LectureJpaEntity.builder()
+			.lectureCode(ENGLISH_CONVERSATION1_CODE)
+			.build();
+		LectureJpaEntity 영어회화2 = LectureJpaEntity.builder()
+			.lectureCode(ENGLISH_CONVERSATION2_CODE)
+			.build();
+		LectureJpaEntity 영어회화3 = LectureJpaEntity.builder()
+			.lectureCode(ENGLISH_CONVERSATION3_CODE)
+			.build();
+		LectureJpaEntity 영어회화4 = LectureJpaEntity.builder()
+			.lectureCode(ENGLISH_CONVERSATION4_CODE)
+			.build();
+		List<LectureJpaEntity> englishLectures = List.of(영어1, 영어2, 영어3, 영어4, 영어회화1, 영어회화2, 영어회화3, 영어회화4);
+		lectureRepository.saveAll(englishLectures);
+
+		for (LectureJpaEntity englishLecture : englishLectures) {
+			CommonCultureJpaEntity commonCultureJpaEntityA = CommonCultureJpaEntity.builder()
+				.lectureJpaEntity(englishLecture)
+				.startEntryYear(16)
+				.endEntryYear(17).build();
+			CommonCultureJpaEntity commonCultureJpaEntityB = CommonCultureJpaEntity.builder()
+				.lectureJpaEntity(englishLecture)
+				.startEntryYear(18)
+				.endEntryYear(19).build();
+			CommonCultureJpaEntity commonCultureJpaEntityC = CommonCultureJpaEntity.builder()
+				.lectureJpaEntity(englishLecture)
+				.startEntryYear(20)
+				.endEntryYear(22).build();
+			CommonCultureJpaEntity commonCultureJpaEntityD = CommonCultureJpaEntity.builder()
+				.lectureJpaEntity(englishLecture)
+				.startEntryYear(23)
+				.endEntryYear(99).build();
+			commonCultureRepository.saveAll(
+				List.of(commonCultureJpaEntityA, commonCultureJpaEntityB, commonCultureJpaEntityC,
+					commonCultureJpaEntityD));
+		}
 	}
 }

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/lecture/adapter/out/persistence/FindCommonCulturePersistenceAdapterTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/lecture/adapter/out/persistence/FindCommonCulturePersistenceAdapterTest.java
@@ -23,6 +23,9 @@ import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
 @Import({LectureMapper.class, FindCommonCulturePersistenceAdapter.class})
 class FindCommonCulturePersistenceAdapterTest extends PersistenceTestSupport {
 
+	private static final String ENGLISH1_CODE = "KMA02106";
+	private static final String ENGLISH_CONVERSATION3_CODE = "KMA02125";
+
 	@Autowired
 	private LectureRepository lectureRepository;
 	@Autowired
@@ -30,38 +33,72 @@ class FindCommonCulturePersistenceAdapterTest extends PersistenceTestSupport {
 	@Autowired
 	private FindCommonCulturePersistenceAdapter commonCulturePersistenceAdapter;
 
-	@DisplayName("유저의 입학년도에 해당하는 공통교양과목들을 조회한다.")
+	@DisplayName("Eng12: 유저의 입학년도와 영어레벨에 해당하는 공통교양과목들을 조회한다.")
 	@Test
-	void findCommonCulture() {
+	void findEng12CommonCulture() {
 	    //given
-		User user = UserFixture.응용소프트웨어학과_19학번();
+		User eng12User = UserFixture.데이테크놀로지학과_18학번();
+		createCommonCultures();
+
+		//when
+		Set<CommonCulture> commonCultures = commonCulturePersistenceAdapter.findCommonCulture(eng12User);
+
+		//then
+		assertThat(commonCultures).hasSize(1)
+			.extracting("commonCultureCategory")
+			.contains(ENGLISH);
+	}
+
+	@DisplayName("Eng12: 유저의 입학년도와 영어레벨에 해당하는 공통교양과목들을 조회한다.")
+	@Test
+	void findEng34CommonCulture() {
+		//given
+		User eng34User = UserFixture.데이테크놀로지학과_16학번_Eng34();
+		createCommonCultures();
+
+		//when
+		Set<CommonCulture> commonCultures = commonCulturePersistenceAdapter.findCommonCulture(eng34User);
+
+		//then
+		assertThat(commonCultures).hasSize(1)
+			.extracting("commonCultureCategory")
+			.contains(ENGLISH);
+	}
+
+	@DisplayName("Eng12: 유저의 입학년도와 영어레벨에 해당하는 공통교양과목들을 조회한다.")
+	@Test
+	void findEngFreeCommonCulture() {
+		//given
+		User engFreeUser = UserFixture.응용소프트웨어학과_19학번_영어_면제();
+		createCommonCultures();
+
+		//when
+		Set<CommonCulture> commonCultures = commonCulturePersistenceAdapter.findCommonCulture(engFreeUser);
+
+		//then
+		assertThat(commonCultures).hasSize(0);
+	}
+
+	private void createCommonCultures() {
 		LectureJpaEntity lectureJpaEntityA = LectureJpaEntity.builder()
-			.lectureCode("testA")
+			.lectureCode(ENGLISH1_CODE)
 			.build();
 		LectureJpaEntity lectureJpaEntityB = LectureJpaEntity.builder()
-			.lectureCode("testB")
+			.lectureCode(ENGLISH_CONVERSATION3_CODE)
 			.build();
 		lectureRepository.saveAll(List.of(lectureJpaEntityA, lectureJpaEntityB));
 
 		CommonCultureJpaEntity commonCultureJpaEntityA = CommonCultureJpaEntity.builder()
 			.lectureJpaEntity(lectureJpaEntityA)
-			.commonCultureCategory(CAREER)
-			.startEntryYear(16)
-			.endEntryYear(18).build();
+			.commonCultureCategory(ENGLISH)
+			.startEntryYear(18)
+			.endEntryYear(23).build();
 		CommonCultureJpaEntity commonCultureJpaEntityB = CommonCultureJpaEntity.builder()
 			.lectureJpaEntity(lectureJpaEntityB)
-			.commonCultureCategory(EXPRESSION)
-			.startEntryYear(19)
-			.endEntryYear(23).build();
+			.commonCultureCategory(ENGLISH)
+			.startEntryYear(16)
+			.endEntryYear(17).build();
 		commonCultureRepository.saveAll(List.of(commonCultureJpaEntityA, commonCultureJpaEntityB));
-
-		//when
-		Set<CommonCulture> commonCultures = commonCulturePersistenceAdapter.findCommonCulture(user);
-
-		//then
-		assertThat(commonCultures).hasSize(1)
-			.extracting("commonCultureCategory")
-			.contains(EXPRESSION);
 	}
 
 }

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/lecture/adapter/out/persistence/FindCommonCulturePersistenceAdapterTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/lecture/adapter/out/persistence/FindCommonCulturePersistenceAdapterTest.java
@@ -24,7 +24,7 @@ import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
 class FindCommonCulturePersistenceAdapterTest extends PersistenceTestSupport {
 
 	private static final String ENGLISH1_CODE = "KMA02106";
-	private static final String ENGLISH_CONVERSATION3_CODE = "KMA02125";
+	private static final String ENGLISH_CONVERSATION3_CODE = "KMA02123";
 
 	@Autowired
 	private LectureRepository lectureRepository;

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/parsing/adaptor/out/persistence/ParsingTextHistoryAdaptorTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/parsing/adaptor/out/persistence/ParsingTextHistoryAdaptorTest.java
@@ -8,11 +8,14 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.plzgraduate.myongjigraduatebe.fixture.UserFixture;
 import com.plzgraduate.myongjigraduatebe.parsing.domain.ParsingResult;
 import com.plzgraduate.myongjigraduatebe.parsing.domain.ParsingTextHistory;
 import com.plzgraduate.myongjigraduatebe.support.PersistenceTestSupport;
+import com.plzgraduate.myongjigraduatebe.user.adaptor.out.persistence.UserJpaEntity;
+import com.plzgraduate.myongjigraduatebe.user.adaptor.out.persistence.UserRepository;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
 
 @Import({ParsingTextHistoryAdaptor.class, ParsingTextHistoryMapper.class})
@@ -24,13 +27,15 @@ class ParsingTextHistoryAdaptorTest extends PersistenceTestSupport {
 	@Autowired
 	private ParsingTextHistoryAdaptor parsingTextHistoryAdaptor;
 
+	@Autowired
+	private UserRepository userRepository;
+
 	@DisplayName("ParsingTextHistory를 저장한다.")
 	@Test
 	void saveParsingTextHistory() {
 		//given
 		User user = UserFixture.경영학과_19학번_ENG34();
-		ParsingTextHistory parsingTextHistory = ParsingTextHistory
-			.builder()
+		ParsingTextHistory parsingTextHistory = ParsingTextHistory.builder()
 			.user(user)
 			.parsingText("text")
 			.parsingResult(ParsingResult.SUCCESS)
@@ -46,5 +51,30 @@ class ParsingTextHistoryAdaptorTest extends PersistenceTestSupport {
 		assertThat(byId.get())
 			.extracting("id", "parsingText", "parsingResult")
 			.contains(1L, "text", ParsingResult.SUCCESS);
+	}
+
+	@DisplayName("유저의 ParsingHistory를 삭제한다.")
+	@Test
+	@Transactional
+	void deleteUserParsingTextHistory() {
+	    //given
+		User user = User.builder().id(1L).build();
+		userRepository.save(UserJpaEntity.builder()
+			.id(1L)
+			.studentNumber("test")
+			.authId("test")
+			.password("test").build());
+		ParsingTextHistory parsingTextHistory = ParsingTextHistory.builder()
+			.user(user)
+			.parsingText("text")
+			.parsingResult(ParsingResult.SUCCESS)
+			.build();
+		parsingTextHistoryAdaptor.saveParsingTextHistory(parsingTextHistory);
+
+		//when
+		parsingTextHistoryAdaptor.deleteUserParsingTextHistory(user);
+
+	    //then
+		assertThat(parsingTextRepository.findAll()).isEmpty();
 	}
 }

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/user/application/service/withdraw/WithDrawUserServiceTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/user/application/service/withdraw/WithDrawUserServiceTest.java
@@ -10,6 +10,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.plzgraduate.myongjigraduatebe.parsing.application.port.out.DeleteParsingTextHistoryPort;
 import com.plzgraduate.myongjigraduatebe.takenlecture.application.port.in.delete.DeleteTakenLectureByUserUseCase;
 import com.plzgraduate.myongjigraduatebe.user.application.port.in.find.FindUserUseCase;
 import com.plzgraduate.myongjigraduatebe.user.application.port.out.DeleteUserPort;
@@ -22,6 +23,8 @@ class WithDrawUserServiceTest {
 	private FindUserUseCase findUserUseCase;
 	@Mock
 	private DeleteTakenLectureByUserUseCase deleteTakenLectureByUserUseCase;
+	@Mock
+	private DeleteParsingTextHistoryPort deleteParsingTextHistoryPort;
 	@Mock
 	private DeleteUserPort deleteUserPort;
 
@@ -39,6 +42,7 @@ class WithDrawUserServiceTest {
 		//when //then
 	    withDrawUserService.withDraw(user.getId());
 		then(deleteTakenLectureByUserUseCase).should().deleteAllTakenLecturesByUser(user);
+		then(deleteParsingTextHistoryPort).should().deleteUserParsingTextHistory(user);
 		then(deleteUserPort).should().deleteUser(user);
 	}
 


### PR DESCRIPTION
## Issue

## ✅ 작업 내용
- **졸업 계산 api**
   - '학과' prefix 누락에 따른 유저 학과 매칭 오류 수정('학과' prefix추가)
   - 각 DetailCategoryResult의 haveToLectures 원소들의 id값 null 해결
   - 총 수강 학점 불일치 오류 해결(각 세부 카테고리 leftCredit 처리 시 takenCredit 감소 로직 추가)
   - 영어레벨에 맞지 않는 졸업과목 조회 수정
   - 총 졸업 학점 불일치 오류 해결(중복으로 계산되던 채플 학점 삭제)

- **회원 탈퇴 api**
   - 회원 탈퇴 시 parsingTextHistory 선 삭제 누락으로 인한 foreign key constraint 에러 해결

## 🤔 고민 했던 부분
## 🔊 도움이 필요한 부분!!
