### PR TITLE
refactor: 회원 탈퇴 api password validation 추가

### DIFF
--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/adaptor/in/web/withdraw/WithDrawController.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/adaptor/in/web/withdraw/WithDrawController.java
@@ -1,6 +1,7 @@
 package com.plzgraduate.myongjigraduatebe.user.adaptor.in.web.withdraw;
 
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import com.plzgraduate.myongjigraduatebe.core.meta.LoginUser;
@@ -17,7 +18,7 @@ public class WithDrawController {
 	private final WithDrawUserUseCase withDrawUserUseCase;
 
 	@DeleteMapping()
-	public void withDraw(@LoginUser Long userId) {
-		withDrawUserUseCase.withDraw(userId);
+	public void withDraw(@LoginUser Long userId, @RequestBody WithDrawRequest withDrawRequest) {
+		withDrawUserUseCase.withDraw(userId, withDrawRequest.toCommand());
 	}
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/adaptor/in/web/withdraw/WithDrawRequest.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/adaptor/in/web/withdraw/WithDrawRequest.java
@@ -1,0 +1,27 @@
+package com.plzgraduate.myongjigraduatebe.user.adaptor.in.web.withdraw;
+
+import javax.validation.constraints.NotBlank;
+
+import com.plzgraduate.myongjigraduatebe.user.application.port.in.withdraw.WithDrawCommand;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class WithDrawRequest {
+
+	@NotBlank(message = "비밀번호를 입력해주세요.")
+	private String password;
+
+	@Builder
+	private WithDrawRequest(String password) {
+		this.password = password;
+	}
+
+	public WithDrawCommand toCommand() {
+		return WithDrawCommand.builder()
+			.password(this.password).build();
+	}
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/application/port/in/withdraw/WithDrawCommand.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/application/port/in/withdraw/WithDrawCommand.java
@@ -1,0 +1,15 @@
+package com.plzgraduate.myongjigraduatebe.user.application.port.in.withdraw;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class WithDrawCommand {
+
+	private final String password;
+
+	@Builder
+	private WithDrawCommand(String password) {
+		this.password = password;
+	}
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/application/port/in/withdraw/WithDrawUserUseCase.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/application/port/in/withdraw/WithDrawUserUseCase.java
@@ -2,5 +2,5 @@ package com.plzgraduate.myongjigraduatebe.user.application.port.in.withdraw;
 
 public interface WithDrawUserUseCase {
 
-	void withDraw(Long userId);
+	void withDraw(Long userId, WithDrawCommand withDrawCommand);
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/application/service/withdraw/WithDrawUserService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/application/service/withdraw/WithDrawUserService.java
@@ -6,7 +6,6 @@ import org.springframework.transaction.annotation.Transactional;
 import com.plzgraduate.myongjigraduatebe.core.meta.UseCase;
 import com.plzgraduate.myongjigraduatebe.parsing.application.port.out.DeleteParsingTextHistoryPort;
 import com.plzgraduate.myongjigraduatebe.takenlecture.application.port.in.delete.DeleteTakenLectureByUserUseCase;
-import com.plzgraduate.myongjigraduatebe.user.adaptor.in.web.withdraw.WithDrawRequest;
 import com.plzgraduate.myongjigraduatebe.user.application.port.in.find.FindUserUseCase;
 import com.plzgraduate.myongjigraduatebe.user.application.port.in.withdraw.WithDrawCommand;
 import com.plzgraduate.myongjigraduatebe.user.application.port.in.withdraw.WithDrawUserUseCase;

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/application/service/withdraw/WithDrawUserService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/application/service/withdraw/WithDrawUserService.java
@@ -1,11 +1,14 @@
 package com.plzgraduate.myongjigraduatebe.user.application.service.withdraw;
 
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.plzgraduate.myongjigraduatebe.core.meta.UseCase;
 import com.plzgraduate.myongjigraduatebe.parsing.application.port.out.DeleteParsingTextHistoryPort;
 import com.plzgraduate.myongjigraduatebe.takenlecture.application.port.in.delete.DeleteTakenLectureByUserUseCase;
+import com.plzgraduate.myongjigraduatebe.user.adaptor.in.web.withdraw.WithDrawRequest;
 import com.plzgraduate.myongjigraduatebe.user.application.port.in.find.FindUserUseCase;
+import com.plzgraduate.myongjigraduatebe.user.application.port.in.withdraw.WithDrawCommand;
 import com.plzgraduate.myongjigraduatebe.user.application.port.in.withdraw.WithDrawUserUseCase;
 import com.plzgraduate.myongjigraduatebe.user.application.port.out.DeleteUserPort;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
@@ -21,10 +24,12 @@ class WithDrawUserService implements WithDrawUserUseCase {
 	private final DeleteTakenLectureByUserUseCase deleteTakenLectureByUserUseCase;
 	private final DeleteParsingTextHistoryPort deleteParsingTextHistoryPort;
 	private final DeleteUserPort deleteUserPort;
+	private final PasswordEncoder passwordEncoder;
 
 	@Override
-	public void withDraw(Long userId) {
+	public void withDraw(Long userId, WithDrawCommand withDrawCommand) {
 		User user = findUserUseCase.findUserById(userId);
+		user.matchPassword(passwordEncoder, withDrawCommand.getPassword());
 		deleteTakenLectureByUserUseCase.deleteAllTakenLecturesByUser(user);
 		deleteParsingTextHistoryPort.deleteUserParsingTextHistory(user);
 		deleteUserPort.deleteUser(user);

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/user/adaptor/in/web/withdraw/WithDrawControllerTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/user/adaptor/in/web/withdraw/WithDrawControllerTest.java
@@ -1,17 +1,19 @@
 package com.plzgraduate.myongjigraduatebe.user.adaptor.in.web.withdraw;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.then;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
 import com.plzgraduate.myongjigraduatebe.support.WebAdaptorTestSupport;
 import com.plzgraduate.myongjigraduatebe.support.WithMockAuthenticationUser;
+import com.plzgraduate.myongjigraduatebe.user.application.port.in.withdraw.WithDrawCommand;
 
 class WithDrawControllerTest extends WebAdaptorTestSupport {
 
@@ -19,16 +21,18 @@ class WithDrawControllerTest extends WebAdaptorTestSupport {
 	@DisplayName("유저의 회원 탈퇴 요청을 수행한다.")
 	@Test
 	void withDraw() throws Exception {
-	    //given
-		Long userId = 1L;
-	
-	    //when
+		//given
+		WithDrawRequest request = WithDrawRequest.builder()
+			.password("abcd1234!").build();
+
+		//when
 		ResultActions actions = mockMvc.perform(
 			delete("/api/v1/users/me")
-				.with(csrf()));
-	
-	    //then
-		then(withDrawUserUseCase).should().withDraw(userId);
+				.content(objectMapper.writeValueAsString(request))
+				.contentType(MediaType.APPLICATION_JSON));
+
+		//then
+		then(withDrawUserUseCase).should().withDraw(any(), any(WithDrawCommand.class));
 		actions.
 			andDo(print())
 			.andExpect(status().isOk());

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/user/application/service/withdraw/WithDrawUserServiceTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/user/application/service/withdraw/WithDrawUserServiceTest.java
@@ -1,5 +1,6 @@
 package com.plzgraduate.myongjigraduatebe.user.application.service.withdraw;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -57,6 +58,28 @@ class WithDrawUserServiceTest {
 		then(deleteTakenLectureByUserUseCase).should().deleteAllTakenLecturesByUser(user);
 		then(deleteParsingTextHistoryPort).should().deleteUserParsingTextHistory(user);
 		then(deleteUserPort).should().deleteUser(user);
+	}
+
+	@DisplayName("잘못된 비밀번호를 입력하면 예외가 발생한다.")
+	@Test
+	void withDrawWithUnValidationPassword() {
+		//given
+		String password = "abcd1234!";
+		PasswordEncoder encoder = new BCryptPasswordEncoder();
+		User user = User.builder()
+			.id(1L)
+			.password(encoder.encode(password)).build();
+		given(findUserUseCase.findUserById(user.getId())).willReturn(user);
+		given(passwordEncoder.matches(anyString(), anyString())).willReturn(false);
+
+		WithDrawCommand withDrawCommand = WithDrawCommand.builder()
+			.password(password).build();
+
+		//when //then
+		assertThatThrownBy(() -> withDrawUserService.withDraw(user.getId(), withDrawCommand))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("비밀번호가 일치하지 않습니다.");
+
 	}
 
 }


### PR DESCRIPTION
## Issue

## ✅ 작업 내용
- 회원탈퇴 api에  누락되었던 user password validation을 추가했습니다

## 🤔 고민 했던 부분

## 🔊 도움이 필요한 부분!!
