### PR TITLE
refactor: TokenController의 API swagger 설정 interface를 상속받도록 변경

### DIFF
--- a/src/main/java/com/plzgraduate/myongjigraduatebe/auth/adaptor/in/web/token/TokenController.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/auth/adaptor/in/web/token/TokenController.java
@@ -15,7 +15,7 @@ import lombok.RequiredArgsConstructor;
 @WebAdapter
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/auth")
-public class TokenController {
+public class TokenController implements TokenApiPresentation {
 
 	private final TokenUseCase tokenUseCase;
 


### PR DESCRIPTION
## ✅ 작업 내용
- TokenController swagger 작업이 누락돼서 추가했습니다