### PR TITLE
[DEV-29] CalculateDetailGraduationUseCaseResolver 구현

### DIFF
--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/api/CalculateDetailGraduationUseCaseResolver.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/api/CalculateDetailGraduationUseCaseResolver.java
@@ -1,0 +1,9 @@
+package com.plzgraduate.myongjigraduatebe.graduation.api;
+
+import com.plzgraduate.myongjigraduatebe.graduation.application.usecase.CalculateDetailGraduationUseCase;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory;
+
+public interface CalculateDetailGraduationUseCaseResolver {
+
+	CalculateDetailGraduationUseCase resolveCalculateDetailGraduationUseCase(GraduationCategory graduationCategory);
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/api/SingleCalculateDetailGraduationUseCaseResolver.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/api/SingleCalculateDetailGraduationUseCaseResolver.java
@@ -1,0 +1,41 @@
+package com.plzgraduate.myongjigraduatebe.graduation.api;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Component;
+
+import com.plzgraduate.myongjigraduatebe.graduation.application.usecase.CalculateDetailGraduationUseCase;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory;
+
+@Component
+public class SingleCalculateDetailGraduationUseCaseResolver implements CalculateDetailGraduationUseCaseResolver {
+
+	private List<CalculateDetailGraduationUseCase> calculateDetailGraduationUseCases;
+
+	private final ApplicationContext applicationContext;
+
+	@Autowired
+	public SingleCalculateDetailGraduationUseCaseResolver(ApplicationContext applicationContext) {
+		this.applicationContext = applicationContext;
+		initCalculateDetailGraduationUseCase();
+	}
+
+	@Override
+	public CalculateDetailGraduationUseCase resolveCalculateDetailGraduationUseCase(
+		GraduationCategory graduationCategory) {
+		return calculateDetailGraduationUseCases.stream()
+			.filter(calculateDetailGraduationUseCase -> calculateDetailGraduationUseCase.supports(graduationCategory))
+			.findFirst()
+			.orElseThrow(() -> new RuntimeException("No calculate detail graduation case found"));
+	}
+
+	private void initCalculateDetailGraduationUseCase() {
+		Map<String, CalculateDetailGraduationUseCase> matchingBeans = applicationContext.getBeansOfType(
+			CalculateDetailGraduationUseCase.class);
+		this.calculateDetailGraduationUseCases = new ArrayList<>(matchingBeans.values());
+	}
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/api/SingleCalculateDetailGraduationUseCaseResolver.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/api/SingleCalculateDetailGraduationUseCaseResolver.java
@@ -1,28 +1,19 @@
 package com.plzgraduate.myongjigraduatebe.graduation.api;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 
 import com.plzgraduate.myongjigraduatebe.graduation.application.usecase.CalculateDetailGraduationUseCase;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory;
 
-@Component
+import lombok.RequiredArgsConstructor;
+
+@Component()
+@RequiredArgsConstructor
 public class SingleCalculateDetailGraduationUseCaseResolver implements CalculateDetailGraduationUseCaseResolver {
 
-	private List<CalculateDetailGraduationUseCase> calculateDetailGraduationUseCases;
-
-	private final ApplicationContext applicationContext;
-
-	@Autowired
-	public SingleCalculateDetailGraduationUseCaseResolver(ApplicationContext applicationContext) {
-		this.applicationContext = applicationContext;
-		initCalculateDetailGraduationUseCase();
-	}
+	private final List<CalculateDetailGraduationUseCase> calculateDetailGraduationUseCases;
 
 	@Override
 	public CalculateDetailGraduationUseCase resolveCalculateDetailGraduationUseCase(
@@ -33,9 +24,4 @@ public class SingleCalculateDetailGraduationUseCaseResolver implements Calculate
 			.orElseThrow(() -> new RuntimeException("No calculate detail graduation case found"));
 	}
 
-	private void initCalculateDetailGraduationUseCase() {
-		Map<String, CalculateDetailGraduationUseCase> matchingBeans = applicationContext.getBeansOfType(
-			CalculateDetailGraduationUseCase.class);
-		this.calculateDetailGraduationUseCases = new ArrayList<>(matchingBeans.values());
-	}
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateCommonCultureGraduationService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateCommonCultureGraduationService.java
@@ -1,0 +1,28 @@
+package com.plzgraduate.myongjigraduatebe.graduation.application.service;
+
+import static com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory.COMMON_CULTURE;
+
+import org.springframework.stereotype.Service;
+
+import com.plzgraduate.myongjigraduatebe.graduation.application.usecase.CalculateCommonCultureGraduationUseCase;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailGraduationResult;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationRequirement;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
+
+@Service
+public class CalculateCommonCultureGraduationService implements CalculateCommonCultureGraduationUseCase {
+
+	@Override
+	public boolean supports(GraduationCategory graduationCategory) {
+		return graduationCategory == COMMON_CULTURE;
+	}
+
+	@Override
+	public DetailGraduationResult calculateDetailGraduation(User user, TakenLectureInventory takenLectureInventory,
+		GraduationRequirement graduationRequirement) {
+		return null;
+	}
+
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateCoreCultureGraduationService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateCoreCultureGraduationService.java
@@ -1,0 +1,28 @@
+package com.plzgraduate.myongjigraduatebe.graduation.application.service;
+
+import static com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory.*;
+
+import org.springframework.stereotype.Service;
+
+import com.plzgraduate.myongjigraduatebe.graduation.application.usecase.CalculateCoreCultureGraduationUseCase;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailGraduationResult;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationRequirement;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
+
+@Service
+public class CalculateCoreCultureGraduationService
+	implements CalculateCoreCultureGraduationUseCase {
+
+	@Override
+	public boolean supports(GraduationCategory graduationCategory) {
+		return graduationCategory == CORE_CULTURE;
+	}
+
+	@Override
+	public DetailGraduationResult calculateDetailGraduation(User user, TakenLectureInventory takenLectureInventory,
+		GraduationRequirement graduationRequirement) {
+		return null;
+	}
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateDualBasicAcademicalCultureDetailGraduationUseService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateDualBasicAcademicalCultureDetailGraduationUseService.java
@@ -1,0 +1,27 @@
+package com.plzgraduate.myongjigraduatebe.graduation.application.service;
+
+import static com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory.DUAL_BASIC_ACADEMICAL_CULTURE;
+
+import org.springframework.stereotype.Service;
+
+import com.plzgraduate.myongjigraduatebe.graduation.application.usecase.CalculateDualBasicAcademicalCultureDetailGraduationUseCase;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailGraduationResult;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationRequirement;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
+
+@Service
+public class CalculateDualBasicAcademicalCultureDetailGraduationUseService implements
+	CalculateDualBasicAcademicalCultureDetailGraduationUseCase {
+	@Override
+	public boolean supports(GraduationCategory graduationCategory) {
+		return graduationCategory == DUAL_BASIC_ACADEMICAL_CULTURE;
+	}
+
+	@Override
+	public DetailGraduationResult calculateDetailGraduation(User user, TakenLectureInventory takenLectureInventory,
+		GraduationRequirement graduationRequirement) {
+		return null;
+	}
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateDualMajorDetailGraduationService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateDualMajorDetailGraduationService.java
@@ -1,0 +1,26 @@
+package com.plzgraduate.myongjigraduatebe.graduation.application.service;
+
+import static com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory.DUAL_MAJOR;
+
+import org.springframework.stereotype.Service;
+
+import com.plzgraduate.myongjigraduatebe.graduation.application.usecase.CalculateDualMajorDetailGraduationUseCase;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailGraduationResult;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationRequirement;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
+
+@Service
+public class CalculateDualMajorDetailGraduationService implements CalculateDualMajorDetailGraduationUseCase {
+	@Override
+	public boolean supports(GraduationCategory graduationCategory) {
+		return graduationCategory == DUAL_MAJOR;
+	}
+
+	@Override
+	public DetailGraduationResult calculateDetailGraduation(User user, TakenLectureInventory takenLectureInventory,
+		GraduationRequirement graduationRequirement) {
+		return null;
+	}
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculatePrimaryBasicAcademicalCultureDetailGraduationService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculatePrimaryBasicAcademicalCultureDetailGraduationService.java
@@ -1,0 +1,27 @@
+package com.plzgraduate.myongjigraduatebe.graduation.application.service;
+
+import static com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory.PRIMARY_BASIC_ACADEMICAL_CULTURE;
+
+import org.springframework.stereotype.Service;
+
+import com.plzgraduate.myongjigraduatebe.graduation.application.usecase.CalculateDetailGraduationUseCase;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailGraduationResult;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationRequirement;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
+
+@Service
+public class CalculatePrimaryBasicAcademicalCultureDetailGraduationService
+	implements CalculateDetailGraduationUseCase {
+	@Override
+	public boolean supports(GraduationCategory graduationCategory) {
+		return graduationCategory == PRIMARY_BASIC_ACADEMICAL_CULTURE;
+	}
+
+	@Override
+	public DetailGraduationResult calculateDetailGraduation(User user, TakenLectureInventory takenLectureInventory,
+		GraduationRequirement graduationRequirement) {
+		return null;
+	}
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculatePrimaryMajorDetailGraduationService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculatePrimaryMajorDetailGraduationService.java
@@ -1,0 +1,26 @@
+package com.plzgraduate.myongjigraduatebe.graduation.application.service;
+
+import static com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory.PRIMARY_MAJOR;
+
+import org.springframework.stereotype.Service;
+
+import com.plzgraduate.myongjigraduatebe.graduation.application.usecase.CalculatePrimaryMajorDetailGraduationUseCase;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailGraduationResult;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationRequirement;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
+
+@Service
+public class CalculatePrimaryMajorDetailGraduationService implements CalculatePrimaryMajorDetailGraduationUseCase {
+	@Override
+	public boolean supports(GraduationCategory graduationCategory) {
+		return graduationCategory == PRIMARY_MAJOR;
+	}
+
+	@Override
+	public DetailGraduationResult calculateDetailGraduation(User user, TakenLectureInventory takenLectureInventory,
+		GraduationRequirement graduationRequirement) {
+		return null;
+	}
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateSubMajorDetailGraduationService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateSubMajorDetailGraduationService.java
@@ -1,0 +1,26 @@
+package com.plzgraduate.myongjigraduatebe.graduation.application.service;
+
+import static com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory.*;
+
+import org.springframework.stereotype.Service;
+
+import com.plzgraduate.myongjigraduatebe.graduation.application.usecase.CalculateSubMajorDetailGraduationUseCase;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailGraduationResult;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationRequirement;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
+
+@Service
+public class CalculateSubMajorDetailGraduationService implements CalculateSubMajorDetailGraduationUseCase {
+	@Override
+	public boolean supports(GraduationCategory graduationCategory) {
+		return graduationCategory == SUB_MAJOR;
+	}
+
+	@Override
+	public DetailGraduationResult calculateDetailGraduation(User user, TakenLectureInventory takenLectureInventory,
+		GraduationRequirement graduationRequirement) {
+		return null;
+	}
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/usecase/CalculateCommonCultureGraduationUseCase.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/usecase/CalculateCommonCultureGraduationUseCase.java
@@ -1,0 +1,4 @@
+package com.plzgraduate.myongjigraduatebe.graduation.application.usecase;
+
+public interface CalculateCommonCultureGraduationUseCase extends CalculateDetailGraduationUseCase{
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/usecase/CalculateCoreCultureGraduationUseCase.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/usecase/CalculateCoreCultureGraduationUseCase.java
@@ -1,0 +1,5 @@
+package com.plzgraduate.myongjigraduatebe.graduation.application.usecase;
+
+public interface CalculateCoreCultureGraduationUseCase extends CalculateDetailGraduationUseCase {
+
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/usecase/CalculateDetailGraduationUseCase.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/usecase/CalculateDetailGraduationUseCase.java
@@ -1,0 +1,15 @@
+package com.plzgraduate.myongjigraduatebe.graduation.application.usecase;
+
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailGraduationResult;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationRequirement;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
+
+public interface CalculateDetailGraduationUseCase {
+
+	boolean supports(GraduationCategory graduationCategory);
+
+	DetailGraduationResult calculateDetailGraduation(User user, TakenLectureInventory takenLectureInventory,
+		GraduationRequirement graduationRequirement);
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/usecase/CalculateDualBasicAcademicalCultureDetailGraduationUseCase.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/usecase/CalculateDualBasicAcademicalCultureDetailGraduationUseCase.java
@@ -1,0 +1,4 @@
+package com.plzgraduate.myongjigraduatebe.graduation.application.usecase;
+
+public interface CalculateDualBasicAcademicalCultureDetailGraduationUseCase extends CalculateDetailGraduationUseCase {
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/usecase/CalculateDualMajorDetailGraduationUseCase.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/usecase/CalculateDualMajorDetailGraduationUseCase.java
@@ -1,0 +1,4 @@
+package com.plzgraduate.myongjigraduatebe.graduation.application.usecase;
+
+public interface CalculateDualMajorDetailGraduationUseCase extends CalculateDetailGraduationUseCase {
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/usecase/CalculatePrimaryBasicAcademicalCultureDetailGraduationUseCase.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/usecase/CalculatePrimaryBasicAcademicalCultureDetailGraduationUseCase.java
@@ -1,0 +1,5 @@
+package com.plzgraduate.myongjigraduatebe.graduation.application.usecase;
+
+public interface CalculatePrimaryBasicAcademicalCultureDetailGraduationUseCase
+	extends CalculateDetailGraduationUseCase {
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/usecase/CalculatePrimaryMajorDetailGraduationUseCase.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/usecase/CalculatePrimaryMajorDetailGraduationUseCase.java
@@ -1,0 +1,4 @@
+package com.plzgraduate.myongjigraduatebe.graduation.application.usecase;
+
+public interface CalculatePrimaryMajorDetailGraduationUseCase extends CalculateDetailGraduationUseCase {
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/usecase/CalculateSubMajorDetailGraduationUseCase.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/usecase/CalculateSubMajorDetailGraduationUseCase.java
@@ -1,0 +1,4 @@
+package com.plzgraduate.myongjigraduatebe.graduation.application.usecase;
+
+public interface CalculateSubMajorDetailGraduationUseCase extends CalculateDetailGraduationUseCase {
+}

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/api/SingleCalculateDetailGraduationUseCaseResolverTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/api/SingleCalculateDetailGraduationUseCaseResolverTest.java
@@ -1,0 +1,37 @@
+package com.plzgraduate.myongjigraduatebe.graduation.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.plzgraduate.myongjigraduatebe.graduation.application.usecase.CalculateDetailGraduationUseCase;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory;
+
+@SpringBootTest
+class SingleCalculateDetailGraduationUseCaseResolverTest {
+
+	@Autowired
+	private SingleCalculateDetailGraduationUseCaseResolver singleCalculateDetailGraduationUseCaseResolver;
+
+	@DisplayName("공통교양 졸업 카테고리를 계산할 수 있는 UseCase를 반환한다.")
+	@ValueSource(strings =
+		{"COMMON_CULTURE", "CORE_CULTURE", "PRIMARY_MAJOR", "DUAL_MAJOR", "SUB_MAJOR",
+			"PRIMARY_BASIC_ACADEMICAL_CULTURE", "DUAL_BASIC_ACADEMICAL_CULTURE"
+		})
+	@ParameterizedTest
+	void resolveCalculateDetailGraduationUseCase(String graduationCategoryName) {
+		//given
+		GraduationCategory graduationCategory = GraduationCategory.valueOf(graduationCategoryName);
+
+		// when
+		CalculateDetailGraduationUseCase calculateDetailGraduationUseCase = singleCalculateDetailGraduationUseCaseResolver.resolveCalculateDetailGraduationUseCase(
+			graduationCategory);
+
+		//then
+		assertThat(calculateDetailGraduationUseCase.supports(graduationCategory)).isEqualTo(true);
+	}
+}

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/api/SingleCalculateDetailGraduationUseCaseResolverTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/api/SingleCalculateDetailGraduationUseCaseResolverTest.java
@@ -7,17 +7,19 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import com.plzgraduate.myongjigraduatebe.graduation.application.usecase.CalculateDetailGraduationUseCase;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class SingleCalculateDetailGraduationUseCaseResolverTest {
 
 	@Autowired
 	private SingleCalculateDetailGraduationUseCaseResolver singleCalculateDetailGraduationUseCaseResolver;
 
-	@DisplayName("공통교양 졸업 카테고리를 계산할 수 있는 UseCase를 반환한다.")
+	@DisplayName("졸업 카테고리를 계산할 수 있는 CalculateDetailGraduationUseCaseResolver 반환한다.")
 	@ValueSource(strings =
 		{"COMMON_CULTURE", "CORE_CULTURE", "PRIMARY_MAJOR", "DUAL_MAJOR", "SUB_MAJOR",
 			"PRIMARY_BASIC_ACADEMICAL_CULTURE", "DUAL_BASIC_ACADEMICAL_CULTURE"


### PR DESCRIPTION
## ✅ 작업 내용
[해당 PR](https://github.com/Myongji-Graduate/MyongjiGraduate-BE/pull/250)에서 논의한 내용을 바탕으로 CalculateDetailGraduationUseCaseResolver를 새로 구현하였습니다.
- CalculateDetailGraduationUseCaseResolver 구현

## 🤔 고민 했던 부분
- 각 GraduationCategory를 지원하는 CalculateDetailGraduationUseCase를 동적으로 결정하기 위한 방법으로 SpringMVC의 DispatcherServlet에 영감을 받아 모든 CalculateDetailGraduationUseCase를 모두 주입받는 것이 아닌 ApplicationContext를 통해 CalculateDetailGraduationUseCase타입 빈들을 조회+리스트업 후 GraduationCategory 여부에 따라 resolve하는 방식으로 구현하였습니다.

위 사항을 반영하여 수정한 다이어그램입니다.
<img width="1198" alt="Screenshot 2024-04-21 at 23 34 27" src="https://github.com/Myongji-Graduate/MyongjiGraduate-BE/assets/106325839/55cd33a3-a268-4d69-885f-8b408a256906">

## 🔊 도움이 필요한 부분!!
- CalculateDetailGraduationUseCaseResolver의 패키지 위치가 어디가 좋을지 의견 부탁드립니다!
