### PR TITLE
[DEV-19] 공통교양 상세 졸업 결과 조회 로직 분리 및 api 개발

### DIFF
--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/api/FindDetailGraduationApiPresentation.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/api/FindDetailGraduationApiPresentation.java
@@ -15,6 +15,6 @@ public interface FindDetailGraduationApiPresentation {
 
 	@Operation(summary = "졸업 카테고리 상세 결과 조회", description = "유저의 각 졸업 카테고리 상세 결과를 조회한다.")
 	@Parameter(name = "graduationCategory", description = "상세 조회하고자 하는 졸업 카테고리")
-	DetailGraduationResultResponse getDetailGraduations(@LoginUser Long userId,
+	DetailGraduationResultResponse getDetailGraduation(@LoginUser Long userId,
 		@RequestParam GraduationCategory graduationCategory);
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/api/FindDetailGraduationApiPresentation.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/api/FindDetailGraduationApiPresentation.java
@@ -11,7 +11,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name = "Graduations")
-public interface FindDetailGraduationsApiPresentation {
+public interface FindDetailGraduationApiPresentation {
 
 	@Operation(summary = "졸업 카테고리 상세 결과 조회", description = "유저의 각 졸업 카테고리 상세 결과를 조회한다.")
 	@Parameter(name = "graduationCategory", description = "상세 조회하고자 하는 졸업 카테고리")

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/api/FindDetailGraduationController.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/api/FindDetailGraduationController.java
@@ -17,9 +17,9 @@ import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCateg
 import lombok.RequiredArgsConstructor;
 
 @WebAdapter
-@RequestMapping("/api/v1/graduations/details")
+@RequestMapping("/api/v1/graduations/detail")
 @RequiredArgsConstructor
-public class FindDetailGraduationsController implements FindDetailGraduationsApiPresentation{
+public class FindDetailGraduationController implements FindDetailGraduationApiPresentation {
 
 	private final CalculateSingleDetailGraduationUseCase calculateSingleDetailGraduationUseCase;
 

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/api/FindDetailGraduationController.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/api/FindDetailGraduationController.java
@@ -1,8 +1,5 @@
 package com.plzgraduate.myongjigraduatebe.graduation.api;
 
-import javax.validation.Valid;
-
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/api/FindDetailGraduationController.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/api/FindDetailGraduationController.java
@@ -24,7 +24,7 @@ public class FindDetailGraduationController implements FindDetailGraduationApiPr
 	private final CalculateSingleDetailGraduationUseCase calculateSingleDetailGraduationUseCase;
 
 	@GetMapping
-	public DetailGraduationResultResponse getDetailGraduations(@LoginUser Long userId,
+	public DetailGraduationResultResponse getDetailGraduation(@LoginUser Long userId,
 		@RequestParam GraduationCategory graduationCategory) {
 		DetailGraduationResult detailGraduationResult = calculateSingleDetailGraduationUseCase.calculateSingleDetailGraduation(
 			userId, graduationCategory);

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/api/FindDetailGraduationsApiPresentation.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/api/FindDetailGraduationsApiPresentation.java
@@ -1,0 +1,20 @@
+package com.plzgraduate.myongjigraduatebe.graduation.api;
+
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.plzgraduate.myongjigraduatebe.core.meta.LoginUser;
+import com.plzgraduate.myongjigraduatebe.graduation.api.dto.response.DetailGraduationResultResponse;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Graduations")
+public interface FindDetailGraduationsApiPresentation {
+
+	@Operation(summary = "졸업 카테고리 상세 결과 조회", description = "유저의 각 졸업 카테고리 상세 결과를 조회한다.")
+	@Parameter(name = "graduationCategory", description = "상세 조회하고자 하는 졸업 카테고리")
+	DetailGraduationResultResponse getDetailGraduations(@LoginUser Long userId,
+		@RequestParam GraduationCategory graduationCategory);
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/api/FindDetailGraduationsController.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/api/FindDetailGraduationsController.java
@@ -1,0 +1,33 @@
+package com.plzgraduate.myongjigraduatebe.graduation.api;
+
+import javax.validation.Valid;
+
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.plzgraduate.myongjigraduatebe.core.meta.LoginUser;
+import com.plzgraduate.myongjigraduatebe.core.meta.WebAdapter;
+import com.plzgraduate.myongjigraduatebe.graduation.api.dto.response.DetailGraduationResultResponse;
+import com.plzgraduate.myongjigraduatebe.graduation.application.usecase.CalculateSingleDetailGraduationUseCase;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailGraduationResult;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory;
+
+import lombok.RequiredArgsConstructor;
+
+@WebAdapter
+@RequestMapping("/api/v1/graduations/details")
+@RequiredArgsConstructor
+public class FindDetailGraduationsController {
+
+	private final CalculateSingleDetailGraduationUseCase calculateSingleDetailGraduationUseCase;
+
+	@GetMapping
+	public DetailGraduationResultResponse getDetailGraduations(@LoginUser Long userId,
+		@RequestParam GraduationCategory graduationCategory) {
+		DetailGraduationResult detailGraduationResult = calculateSingleDetailGraduationUseCase.calculateSingleDetailGraduation(
+			userId, graduationCategory);
+		return DetailGraduationResultResponse.from(detailGraduationResult);
+	}
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/api/FindDetailGraduationsController.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/api/FindDetailGraduationsController.java
@@ -19,7 +19,7 @@ import lombok.RequiredArgsConstructor;
 @WebAdapter
 @RequestMapping("/api/v1/graduations/details")
 @RequiredArgsConstructor
-public class FindDetailGraduationsController {
+public class FindDetailGraduationsController implements FindDetailGraduationsApiPresentation{
 
 	private final CalculateSingleDetailGraduationUseCase calculateSingleDetailGraduationUseCase;
 

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/api/dto/response/DetailGraduationCategoryResultResponse.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/api/dto/response/DetailGraduationCategoryResultResponse.java
@@ -14,21 +14,21 @@ public class DetailGraduationCategoryResultResponse {
 
 	@Schema(name = "categoryName", example = "공통교양(기독교)")
 	private final String categoryName;
-	@Schema(name = "totalCredits", example = "4")
-	private final int totalCredits;
-	@Schema(name = "takenCredits", example = "4")
-	private final int takenCredits;
+	@Schema(name = "totalCredit", example = "4")
+	private final int totalCredit;
+	@Schema(name = "takenCredit", example = "4")
+	private final int takenCredit;
 	private final List<LectureResponse> takenLectures;
 	private final List<LectureResponse> haveToLectures;
 	@Schema(name = "completed", example = "true")
 	private final boolean completed;
 
 	@Builder
-	private DetailGraduationCategoryResultResponse(String categoryName, int totalCredits, int takenCredits,
+	private DetailGraduationCategoryResultResponse(String categoryName, int totalCredit, int takenCredit,
 		List<LectureResponse> takenLectures, List<LectureResponse> haveToLectures, boolean completed) {
 		this.categoryName = categoryName;
-		this.totalCredits = totalCredits;
-		this.takenCredits = takenCredits;
+		this.totalCredit = totalCredit;
+		this.takenCredit = takenCredit;
 		this.takenLectures = takenLectures;
 		this.haveToLectures = haveToLectures;
 		this.completed = completed;
@@ -37,8 +37,8 @@ public class DetailGraduationCategoryResultResponse {
 	public static DetailGraduationCategoryResultResponse from(DetailCategoryResult detailCategoryResult) {
 		return DetailGraduationCategoryResultResponse.builder()
 			.categoryName(detailCategoryResult.getDetailCategoryName())
-			.totalCredits(detailCategoryResult.getTotalCredits())
-			.takenCredits(detailCategoryResult.getTakenCredits())
+			.totalCredit(detailCategoryResult.getTotalCredits())
+			.takenCredit(detailCategoryResult.getTakenCredits())
 			.takenLectures(detailCategoryResult.getTakenLectures().stream()
 				.map(LectureResponse::from)
 				.collect(Collectors.toList()))

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateCommonCultureGraduationService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateCommonCultureGraduationService.java
@@ -1,18 +1,31 @@
 package com.plzgraduate.myongjigraduatebe.graduation.application.service;
 
-import static com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory.COMMON_CULTURE;
+import static com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory.*;
+
+import java.util.Set;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.plzgraduate.myongjigraduatebe.graduation.application.usecase.CalculateCommonCultureGraduationUseCase;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailGraduationResult;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationRequirement;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.service.GraduationManager;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.service.commonculture.CommonCultureGraduationManager;
+import com.plzgraduate.myongjigraduatebe.lecture.application.port.FindCommonCulturePort;
+import com.plzgraduate.myongjigraduatebe.lecture.domain.model.CommonCulture;
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
 
+import lombok.RequiredArgsConstructor;
+
 @Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class CalculateCommonCultureGraduationService implements CalculateCommonCultureGraduationUseCase {
+
+	private final FindCommonCulturePort findCommonCulturePort;
 
 	@Override
 	public boolean supports(GraduationCategory graduationCategory) {
@@ -22,7 +35,10 @@ public class CalculateCommonCultureGraduationService implements CalculateCommonC
 	@Override
 	public DetailGraduationResult calculateDetailGraduation(User user, TakenLectureInventory takenLectureInventory,
 		GraduationRequirement graduationRequirement) {
-		return null;
+		Set<CommonCulture> graduationCommonCultures = findCommonCulturePort.findCommonCulture(user);
+		GraduationManager<CommonCulture> commonCultureGraduationManager = new CommonCultureGraduationManager();
+		return commonCultureGraduationManager.createDetailGraduationResult(
+			user, takenLectureInventory, graduationCommonCultures, graduationRequirement.getCommonCultureCredit());
 	}
 
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateCommonCultureGraduationService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateCommonCultureGraduationService.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.plzgraduate.myongjigraduatebe.core.meta.UseCase;
 import com.plzgraduate.myongjigraduatebe.graduation.application.usecase.CalculateCommonCultureGraduationUseCase;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailGraduationResult;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory;
@@ -20,7 +21,7 @@ import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
 
 import lombok.RequiredArgsConstructor;
 
-@Service
+@UseCase
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class CalculateCommonCultureGraduationService implements CalculateCommonCultureGraduationUseCase {

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateCoreCultureGraduationService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateCoreCultureGraduationService.java
@@ -4,6 +4,7 @@ import static com.plzgraduate.myongjigraduatebe.graduation.domain.model.Graduati
 
 import org.springframework.stereotype.Service;
 
+import com.plzgraduate.myongjigraduatebe.core.meta.UseCase;
 import com.plzgraduate.myongjigraduatebe.graduation.application.usecase.CalculateCoreCultureGraduationUseCase;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailGraduationResult;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory;
@@ -11,7 +12,7 @@ import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationRequi
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
 
-@Service
+@UseCase
 public class CalculateCoreCultureGraduationService
 	implements CalculateCoreCultureGraduationUseCase {
 

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateDualBasicAcademicalCultureDetailGraduationUseService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateDualBasicAcademicalCultureDetailGraduationUseService.java
@@ -4,6 +4,7 @@ import static com.plzgraduate.myongjigraduatebe.graduation.domain.model.Graduati
 
 import org.springframework.stereotype.Service;
 
+import com.plzgraduate.myongjigraduatebe.core.meta.UseCase;
 import com.plzgraduate.myongjigraduatebe.graduation.application.usecase.CalculateDualBasicAcademicalCultureDetailGraduationUseCase;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailGraduationResult;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory;
@@ -11,7 +12,7 @@ import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationRequi
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
 
-@Service
+@UseCase
 public class CalculateDualBasicAcademicalCultureDetailGraduationUseService implements
 	CalculateDualBasicAcademicalCultureDetailGraduationUseCase {
 	@Override

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateDualMajorDetailGraduationService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateDualMajorDetailGraduationService.java
@@ -4,6 +4,7 @@ import static com.plzgraduate.myongjigraduatebe.graduation.domain.model.Graduati
 
 import org.springframework.stereotype.Service;
 
+import com.plzgraduate.myongjigraduatebe.core.meta.UseCase;
 import com.plzgraduate.myongjigraduatebe.graduation.application.usecase.CalculateDualMajorDetailGraduationUseCase;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailGraduationResult;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory;
@@ -11,7 +12,7 @@ import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationRequi
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
 
-@Service
+@UseCase
 public class CalculateDualMajorDetailGraduationService implements CalculateDualMajorDetailGraduationUseCase {
 	@Override
 	public boolean supports(GraduationCategory graduationCategory) {

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateGraduationService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateGraduationService.java
@@ -98,7 +98,7 @@ class CalculateGraduationService implements CalculateGraduationUseCase {
 	private DetailGraduationResult generateCommonCultureDetailGraduationResult(User user,
 		TakenLectureInventory takenLectureInventory, GraduationRequirement graduationRequirement) {
 		return calculateCommonCultureGraduationUseCase.calculateDetailGraduation(user, takenLectureInventory,
-			graduationRequirement.getCommonCultureCredit());
+			graduationRequirement);
 	}
 
 	private DetailGraduationResult generateCoreCultureDetailGraduationResult(User user,

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateGraduationService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateGraduationService.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.plzgraduate.myongjigraduatebe.core.meta.UseCase;
+import com.plzgraduate.myongjigraduatebe.graduation.application.usecase.CalculateCommonCultureGraduationUseCase;
 import com.plzgraduate.myongjigraduatebe.graduation.application.usecase.CalculateGraduationUseCase;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.ChapelResult;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DefaultGraduationRequirementType;
@@ -17,16 +18,13 @@ import com.plzgraduate.myongjigraduatebe.graduation.domain.service.GraduationMan
 import com.plzgraduate.myongjigraduatebe.graduation.domain.service.basicacademicalculture.BusinessBasicAcademicalManager;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.service.basicacademicalculture.DefaultBasicAcademicalManager;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.service.basicacademicalculture.SocialScienceBasicAcademicManager;
-import com.plzgraduate.myongjigraduatebe.graduation.domain.service.commonculture.CommonCultureGraduationManager;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.service.coreculture.CoreCultureGraduationManager;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.service.major.MajorManager;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.service.submajor.SubMajorManager;
 import com.plzgraduate.myongjigraduatebe.lecture.application.port.FindBasicAcademicalCulturePort;
-import com.plzgraduate.myongjigraduatebe.lecture.application.port.FindCommonCulturePort;
 import com.plzgraduate.myongjigraduatebe.lecture.application.port.FindCoreCulturePort;
 import com.plzgraduate.myongjigraduatebe.lecture.application.port.FindMajorPort;
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.BasicAcademicalCultureLecture;
-import com.plzgraduate.myongjigraduatebe.lecture.domain.model.CommonCulture;
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.CoreCulture;
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.MajorLecture;
 import com.plzgraduate.myongjigraduatebe.takenlecture.application.usecase.find.FindTakenLectureUseCase;
@@ -40,18 +38,19 @@ import lombok.RequiredArgsConstructor;
 @UseCase
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
-//TODO: 로직 분리 후 테스트 코드 작성
 class CalculateGraduationService implements CalculateGraduationUseCase {
 
-	private final FindCommonCulturePort findCommonCulturePort;
 	private final FindCoreCulturePort findCoreCulturePort;
 	private final FindBasicAcademicalCulturePort findBasicAcademicalCulturePort;
 	private final FindMajorPort findMajorPort;
 	private final FindTakenLectureUseCase findTakenLectureUseCase;
 
+	private final CalculateCommonCultureGraduationUseCase calculateCommonCultureGraduationUseCase;
+
 	@Override
 	public GraduationResult calculateGraduation(User user) {
 		GraduationRequirement graduationRequirement = determineGraduationRequirement(user);
+		// 모든 DetialCategory 분리 시 제거
 		TakenLectureInventory takenLectureInventory = findTakenLectureUseCase.findTakenLectures(user.getId());
 
 		ChapelResult chapelResult = generateChapelResult(takenLectureInventory);
@@ -98,10 +97,8 @@ class CalculateGraduationService implements CalculateGraduationUseCase {
 
 	private DetailGraduationResult generateCommonCultureDetailGraduationResult(User user,
 		TakenLectureInventory takenLectureInventory, GraduationRequirement graduationRequirement) {
-		Set<CommonCulture> graduationCommonCultures = findCommonCulturePort.findCommonCulture(user);
-		GraduationManager<CommonCulture> commonCultureGraduationManager = new CommonCultureGraduationManager();
-		return commonCultureGraduationManager.createDetailGraduationResult(
-			user, takenLectureInventory, graduationCommonCultures, graduationRequirement.getCommonCultureCredit());
+		return calculateCommonCultureGraduationUseCase.calculateDetailGraduation(user, takenLectureInventory,
+			graduationRequirement.getCommonCultureCredit());
 	}
 
 	private DetailGraduationResult generateCoreCultureDetailGraduationResult(User user,

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculatePrimaryBasicAcademicalCultureDetailGraduationService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculatePrimaryBasicAcademicalCultureDetailGraduationService.java
@@ -4,6 +4,7 @@ import static com.plzgraduate.myongjigraduatebe.graduation.domain.model.Graduati
 
 import org.springframework.stereotype.Service;
 
+import com.plzgraduate.myongjigraduatebe.core.meta.UseCase;
 import com.plzgraduate.myongjigraduatebe.graduation.application.usecase.CalculateDetailGraduationUseCase;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailGraduationResult;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory;
@@ -11,7 +12,7 @@ import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationRequi
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
 
-@Service
+@UseCase
 public class CalculatePrimaryBasicAcademicalCultureDetailGraduationService
 	implements CalculateDetailGraduationUseCase {
 	@Override

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculatePrimaryMajorDetailGraduationService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculatePrimaryMajorDetailGraduationService.java
@@ -4,6 +4,7 @@ import static com.plzgraduate.myongjigraduatebe.graduation.domain.model.Graduati
 
 import org.springframework.stereotype.Service;
 
+import com.plzgraduate.myongjigraduatebe.core.meta.UseCase;
 import com.plzgraduate.myongjigraduatebe.graduation.application.usecase.CalculatePrimaryMajorDetailGraduationUseCase;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailGraduationResult;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory;
@@ -11,7 +12,7 @@ import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationRequi
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
 
-@Service
+@UseCase
 public class CalculatePrimaryMajorDetailGraduationService implements CalculatePrimaryMajorDetailGraduationUseCase {
 	@Override
 	public boolean supports(GraduationCategory graduationCategory) {

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateSingleDetailGraduationService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateSingleDetailGraduationService.java
@@ -3,6 +3,7 @@ package com.plzgraduate.myongjigraduatebe.graduation.application.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.plzgraduate.myongjigraduatebe.core.meta.UseCase;
 import com.plzgraduate.myongjigraduatebe.graduation.api.CalculateDetailGraduationUseCaseResolver;
 import com.plzgraduate.myongjigraduatebe.graduation.application.usecase.CalculateDetailGraduationUseCase;
 import com.plzgraduate.myongjigraduatebe.graduation.application.usecase.CalculateSingleDetailGraduationUseCase;
@@ -18,7 +19,7 @@ import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
 
 import lombok.RequiredArgsConstructor;
 
-@Service
+@UseCase
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class CalculateSingleDetailGraduationService implements CalculateSingleDetailGraduationUseCase {

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateSingleDetailGraduationService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateSingleDetailGraduationService.java
@@ -1,10 +1,9 @@
 package com.plzgraduate.myongjigraduatebe.graduation.application.service;
 
-import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.plzgraduate.myongjigraduatebe.core.meta.UseCase;
-import com.plzgraduate.myongjigraduatebe.graduation.api.CalculateDetailGraduationUseCaseResolver;
+import com.plzgraduate.myongjigraduatebe.graduation.support.resolver.CalculateDetailGraduationUseCaseResolver;
 import com.plzgraduate.myongjigraduatebe.graduation.application.usecase.CalculateDetailGraduationUseCase;
 import com.plzgraduate.myongjigraduatebe.graduation.application.usecase.CalculateSingleDetailGraduationUseCase;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DefaultGraduationRequirementType;

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateSingleDetailGraduationService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateSingleDetailGraduationService.java
@@ -1,0 +1,47 @@
+package com.plzgraduate.myongjigraduatebe.graduation.application.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.plzgraduate.myongjigraduatebe.graduation.api.CalculateDetailGraduationUseCaseResolver;
+import com.plzgraduate.myongjigraduatebe.graduation.application.usecase.CalculateDetailGraduationUseCase;
+import com.plzgraduate.myongjigraduatebe.graduation.application.usecase.CalculateSingleDetailGraduationUseCase;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DefaultGraduationRequirementType;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailGraduationResult;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationRequirement;
+import com.plzgraduate.myongjigraduatebe.takenlecture.application.usecase.find.FindTakenLectureUseCase;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
+import com.plzgraduate.myongjigraduatebe.user.application.usecase.find.FindUserUseCase;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.College;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CalculateSingleDetailGraduationService implements CalculateSingleDetailGraduationUseCase {
+
+	private final FindUserUseCase findUserUseCase;
+	private final FindTakenLectureUseCase findTakenLectureUseCase;
+	private final CalculateDetailGraduationUseCaseResolver calculateDetailGraduationUseCaseResolver;
+
+	@Override
+	public DetailGraduationResult calculateSingleDetailGraduation(Long userId, GraduationCategory graduationCategory) {
+		User user = findUserUseCase.findUserById(userId);
+		TakenLectureInventory takenLectures = findTakenLectureUseCase.findTakenLectures(userId);
+		CalculateDetailGraduationUseCase calculateDetailGraduationUseCase = calculateDetailGraduationUseCaseResolver.resolveCalculateDetailGraduationUseCase(
+			graduationCategory);
+		GraduationRequirement graduationRequirement = determineGraduationRequirement(user);
+
+		return calculateDetailGraduationUseCase.calculateDetailGraduation(user, takenLectures, graduationRequirement);
+	}
+
+	private GraduationRequirement determineGraduationRequirement(User user) {
+		College userCollage = College.findBelongingCollege(user.getPrimaryMajor());
+		DefaultGraduationRequirementType defaultGraduationRequirement = DefaultGraduationRequirementType.determineGraduationRequirement(
+			userCollage, user);
+		return defaultGraduationRequirement.convertToProfitGraduationRequirement(user);
+	}
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateSubMajorDetailGraduationService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateSubMajorDetailGraduationService.java
@@ -4,6 +4,7 @@ import static com.plzgraduate.myongjigraduatebe.graduation.domain.model.Graduati
 
 import org.springframework.stereotype.Service;
 
+import com.plzgraduate.myongjigraduatebe.core.meta.UseCase;
 import com.plzgraduate.myongjigraduatebe.graduation.application.usecase.CalculateSubMajorDetailGraduationUseCase;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailGraduationResult;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory;
@@ -11,7 +12,7 @@ import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationRequi
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
 
-@Service
+@UseCase
 public class CalculateSubMajorDetailGraduationService implements CalculateSubMajorDetailGraduationUseCase {
 	@Override
 	public boolean supports(GraduationCategory graduationCategory) {

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/usecase/CalculateSingleDetailGraduationUseCase.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/usecase/CalculateSingleDetailGraduationUseCase.java
@@ -1,0 +1,10 @@
+package com.plzgraduate.myongjigraduatebe.graduation.application.usecase;
+
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailGraduationResult;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory;
+
+public interface CalculateSingleDetailGraduationUseCase {
+
+	DetailGraduationResult calculateSingleDetailGraduation(Long userId, GraduationCategory graduationCategory);
+
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/ChapelResult.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/ChapelResult.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 @Getter
 public class ChapelResult {
 
-	private static final String CHAPEL_LECTURE_CODE = "KMA02101";
+	public static final String CHAPEL_LECTURE_CODE = "KMA02101";
 	public static final int GRADUATION_COUNT = 4;
 
 	private final int takenCount;

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/ChapelResult.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/ChapelResult.java
@@ -10,6 +10,7 @@ public class ChapelResult {
 
 	public static final String CHAPEL_LECTURE_CODE = "KMA02101";
 	public static final int GRADUATION_COUNT = 4;
+	public static final double CHAPEL_CREDIT = 0.5;
 
 	private final int takenCount;
 	private boolean isCompleted;
@@ -31,7 +32,7 @@ public class ChapelResult {
 	}
 
 	public double getTakenChapelCredit() {
-		return takenCount * 0.5;
+		return takenCount * CHAPEL_CREDIT;
 	}
 
 	private static int countTakenChapel(TakenLectureInventory takenLectureInventory) {

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/GraduationResult.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/GraduationResult.java
@@ -54,7 +54,6 @@ public class GraduationResult {
 	public void checkGraduated() {
 		addUpTotalCredit();
 		addUpTakenCredit();
-		addUpChapelTakenCreditToCommonCulture();
 
 		boolean isAllDetailGraduationResultCompleted = detailGraduationResults.stream()
 			.allMatch(DetailGraduationResult::isCompleted);
@@ -79,12 +78,6 @@ public class GraduationResult {
 			+ chapelResult.getTakenChapelCredit();
 	}
 
-	private void addUpChapelTakenCreditToCommonCulture() {
-		this.detailGraduationResults.stream()
-			.filter(detailGraduationResult -> detailGraduationResult.getGraduationCategory() ==COMMON_CULTURE)
-			.forEach(
-				detailGraduationResult -> detailGraduationResult.addCredit(this.chapelResult.getTakenChapelCredit()));
-	}
 
 	private void handleLeftTakenNormaCulture(TakenLectureInventory takenLectureInventory,
 		GraduationRequirement graduationRequirement) {

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/commonculture/CommonCultureGraduationManager.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/commonculture/CommonCultureGraduationManager.java
@@ -1,5 +1,6 @@
 package com.plzgraduate.myongjigraduatebe.graduation.domain.service.commonculture;
 
+import static com.plzgraduate.myongjigraduatebe.graduation.domain.model.ChapelResult.*;
 import static com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory.*;
 
 import java.util.Arrays;
@@ -38,14 +39,9 @@ public class CommonCultureGraduationManager implements GraduationManager<CommonC
 
 	private double getTakenChapelCredits(TakenLectureInventory takenLectureInventory) {
 		int chapelCount = (int)takenLectureInventory.getTakenLectures().stream()
-			.filter(takenLecture -> takenLecture.getLecture().getLectureCode().equals(ChapelResult.CHAPEL_LECTURE_CODE))
+			.filter(takenLecture -> takenLecture.getLecture().getLectureCode().equals(CHAPEL_LECTURE_CODE))
 			.count();
-		return chapelCount * 0.5;
+		return chapelCount * CHAPEL_CREDIT;
 
-		// this.detailGraduationResults.stream()
-		// 	.filter(detailGraduationResult -> detailGraduationResult.getGraduationCategory() ==COMMON_CULTURE)
-		// 	.forEach(
-		// 		detailGraduationResult -> detailGraduationResult.addCredit(this.chapelResult.getTakenChapelCredit()));
 	}
-
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/commonculture/CommonCultureGraduationManager.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/commonculture/CommonCultureGraduationManager.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.ChapelResult;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailCategoryResult;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailGraduationResult;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.service.GraduationManager;
@@ -29,8 +30,22 @@ public class CommonCultureGraduationManager implements GraduationManager<CommonC
 				graduationLectures, commonCultureCategory))
 			.collect(Collectors.toList());
 
-		return DetailGraduationResult.create(COMMON_CULTURE, commonCultureGraduationTotalCredit,
-			commonCultureDetailCategoryResults);
+		DetailGraduationResult detailGraduationResult = DetailGraduationResult.create(COMMON_CULTURE,
+			commonCultureGraduationTotalCredit, commonCultureDetailCategoryResults);
+		detailGraduationResult.addCredit(getTakenChapelCredits(takenLectureInventory));
+		return detailGraduationResult;
+	}
+
+	private double getTakenChapelCredits(TakenLectureInventory takenLectureInventory) {
+		int chapelCount = (int)takenLectureInventory.getTakenLectures().stream()
+			.filter(takenLecture -> takenLecture.getLecture().getLectureCode().equals(ChapelResult.CHAPEL_LECTURE_CODE))
+			.count();
+		return chapelCount * 0.5;
+
+		// this.detailGraduationResults.stream()
+		// 	.filter(detailGraduationResult -> detailGraduationResult.getGraduationCategory() ==COMMON_CULTURE)
+		// 	.forEach(
+		// 		detailGraduationResult -> detailGraduationResult.addCredit(this.chapelResult.getTakenChapelCredit()));
 	}
 
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/support/resolver/CalculateDetailGraduationUseCaseResolver.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/support/resolver/CalculateDetailGraduationUseCaseResolver.java
@@ -1,4 +1,4 @@
-package com.plzgraduate.myongjigraduatebe.graduation.api;
+package com.plzgraduate.myongjigraduatebe.graduation.support.resolver;
 
 import com.plzgraduate.myongjigraduatebe.graduation.application.usecase.CalculateDetailGraduationUseCase;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory;

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/support/resolver/SingleCalculateDetailGraduationUseCaseResolver.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/support/resolver/SingleCalculateDetailGraduationUseCaseResolver.java
@@ -1,4 +1,4 @@
-package com.plzgraduate.myongjigraduatebe.graduation.api;
+package com.plzgraduate.myongjigraduatebe.graduation.support.resolver;
 
 import java.util.List;
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,9 +17,6 @@ spring:
         format_sql: true
     open-in-view: false
 
-  jackson:
-    default-property-inclusion: non_null
-
 logging:
   level:
     p6spy: info

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/api/FindDetailGraduationsControllerTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/api/FindDetailGraduationsControllerTest.java
@@ -1,0 +1,55 @@
+package com.plzgraduate.myongjigraduatebe.graduation.api;
+
+import static com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory.COMMON_CULTURE;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailCategoryResult;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailGraduationResult;
+import com.plzgraduate.myongjigraduatebe.support.WebAdaptorTestSupport;
+import com.plzgraduate.myongjigraduatebe.support.WithMockAuthenticationUser;
+
+class FindDetailGraduationsControllerTest extends WebAdaptorTestSupport {
+
+	@WithMockAuthenticationUser
+	@DisplayName("공통교양 졸업 상세 결과를 조회한다.")
+	@Test
+	void getDetailGraduations() throws Exception {
+		//given
+		List<DetailCategoryResult> detailCategories = List.of(
+			DetailCategoryResult.builder().build(),
+			DetailCategoryResult.builder().build(),
+			DetailCategoryResult.builder().build(),
+			DetailCategoryResult.builder().build()
+		);
+		DetailGraduationResult detailGraduationResult = DetailGraduationResult.builder()
+			.graduationCategory(COMMON_CULTURE)
+			.totalCredit(17)
+			.takenCredit(17)
+			.isCompleted(true)
+			.detailCategory(detailCategories)
+			.build();
+
+		given(calculateSingleDetailGraduationUseCase.calculateSingleDetailGraduation(1L,
+			COMMON_CULTURE)).willReturn(detailGraduationResult);
+
+		//when //then
+		mockMvc.perform(get("/api/v1/graduations/details")
+				.param("graduationCategory", "COMMON_CULTURE"))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.totalCredit").value(17))
+			.andExpect(jsonPath("$.takenCredit").value(17))
+			.andExpect(jsonPath("$.completed").value(true))
+			.andExpect(jsonPath("$.detailCategory.length()").value(detailCategories.size()));
+	}
+
+}

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/api/FindDetailGraduationsControllerTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/api/FindDetailGraduationsControllerTest.java
@@ -42,7 +42,7 @@ class FindDetailGraduationsControllerTest extends WebAdaptorTestSupport {
 			COMMON_CULTURE)).willReturn(detailGraduationResult);
 
 		//when //then
-		mockMvc.perform(get("/api/v1/graduations/details")
+		mockMvc.perform(get("/api/v1/graduations/detail")
 				.param("graduationCategory", "COMMON_CULTURE"))
 			.andDo(print())
 			.andExpect(status().isOk())

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/api/FindDetailGraduationsControllerTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/api/FindDetailGraduationsControllerTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
 
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailCategoryResult;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailGraduationResult;
@@ -22,7 +23,7 @@ class FindDetailGraduationsControllerTest extends WebAdaptorTestSupport {
 	@WithMockAuthenticationUser
 	@DisplayName("공통교양 졸업 상세 결과를 조회한다.")
 	@Test
-	void getDetailGraduations() throws Exception {
+	void getCommonDetailGraduations() throws Exception {
 		//given
 		List<DetailCategoryResult> detailCategories = List.of(
 			DetailCategoryResult.builder().build(),
@@ -50,6 +51,22 @@ class FindDetailGraduationsControllerTest extends WebAdaptorTestSupport {
 			.andExpect(jsonPath("$.takenCredit").value(17))
 			.andExpect(jsonPath("$.completed").value(true))
 			.andExpect(jsonPath("$.detailCategory.length()").value(detailCategories.size()));
+	}
+
+	@WithMockAuthenticationUser
+	@DisplayName("GraduationCategory에 해당하지 않는 졸업 상세 조회 시 에러를 반환한다.")
+	@Test
+	void getDetailGraduationsWithInvalidGraduationCategory() throws Exception {
+		//given
+		String invalidGraduationCategoryName = "COMMON_CULTUR";
+
+		//when //then
+		mockMvc.perform(get("/api/v1/graduations/detail")
+				.param("graduationCategory", invalidGraduationCategoryName))
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+			.andExpect(jsonPath("$.message").value("Failed to convert value: " + invalidGraduationCategoryName));
 	}
 
 }

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/api/SingleCalculateDetailGraduationUseCaseResolverTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/api/SingleCalculateDetailGraduationUseCaseResolverTest.java
@@ -11,6 +11,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 import com.plzgraduate.myongjigraduatebe.graduation.application.usecase.CalculateDetailGraduationUseCase;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory;
+import com.plzgraduate.myongjigraduatebe.graduation.support.resolver.SingleCalculateDetailGraduationUseCaseResolver;
 
 @SpringBootTest
 @ActiveProfiles("test")

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateCommonCultureGraduationServiceTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateCommonCultureGraduationServiceTest.java
@@ -1,0 +1,67 @@
+package com.plzgraduate.myongjigraduatebe.graduation.application.service;
+
+import static com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory.COMMON_CULTURE;
+import static com.plzgraduate.myongjigraduatebe.lecture.domain.model.CommonCultureCategory.CHRISTIAN_A;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailGraduationResult;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationRequirement;
+import com.plzgraduate.myongjigraduatebe.lecture.application.port.FindCommonCulturePort;
+import com.plzgraduate.myongjigraduatebe.lecture.domain.model.CommonCulture;
+import com.plzgraduate.myongjigraduatebe.lecture.domain.model.Lecture;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLecture;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
+
+@ExtendWith(MockitoExtension.class)
+class CalculateCommonCultureGraduationServiceTest {
+
+	@Mock
+	private FindCommonCulturePort findCommonCulturePort;
+	@InjectMocks
+	private CalculateCommonCultureGraduationService calculateCommonCultureGraduationService;
+
+	@DisplayName("유저의 공통교양 상세 졸업결과를 계산한다.")
+	@Test
+	void calculateCommonCulture() {
+		//given
+		User user = User.builder()
+			.id(1L)
+			.primaryMajor("응용소프트웨어전공")
+			.entryYear(19).build();
+		HashSet<CommonCulture> graduationCommonCultures = new HashSet<>(
+			Set.of(CommonCulture.of(Lecture.from("KMA00101"), CHRISTIAN_A)));
+		given(findCommonCulturePort.findCommonCulture(user)).willReturn(graduationCommonCultures);
+
+		HashSet<TakenLecture> takenLectures = new HashSet<>(
+			Set.of(
+				TakenLecture.builder().lecture(Lecture.builder()
+					.lectureCode("KMA00101")
+					.credit(2).build()).build()));
+		TakenLectureInventory takenLectureInventory = TakenLectureInventory.from(takenLectures);
+
+		GraduationRequirement graduationRequirement = GraduationRequirement.builder()
+			.commonCultureCredit(17).build();
+
+		//when
+		DetailGraduationResult detailCommonCultureGraduationResult = calculateCommonCultureGraduationService.calculateDetailGraduation(
+			user, takenLectureInventory, graduationRequirement);
+
+		//then
+		assertThat(detailCommonCultureGraduationResult)
+			.extracting("graduationCategory", "isCompleted", "totalCredit", "takenCredit")
+			.contains(COMMON_CULTURE, false, 17, 2.0);
+	}
+
+}

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateSingleDetailGraduationServiceTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateSingleDetailGraduationServiceTest.java
@@ -1,0 +1,76 @@
+package com.plzgraduate.myongjigraduatebe.graduation.application.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.util.HashSet;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.plzgraduate.myongjigraduatebe.graduation.api.CalculateDetailGraduationUseCaseResolver;
+import com.plzgraduate.myongjigraduatebe.graduation.application.usecase.CalculateDetailGraduationUseCase;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationRequirement;
+import com.plzgraduate.myongjigraduatebe.takenlecture.application.usecase.find.FindTakenLectureUseCase;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
+import com.plzgraduate.myongjigraduatebe.user.application.usecase.find.FindUserUseCase;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
+
+@ExtendWith(MockitoExtension.class)
+class
+CalculateSingleDetailGraduationServiceTest {
+
+	@Mock
+	private FindUserUseCase findUserUseCase;
+	@Mock
+	private FindTakenLectureUseCase findTakenLectureUseCase;
+	@Mock
+	private CalculateDetailGraduationUseCaseResolver calculateDetailGraduationUseCaseResolver;
+	@Mock
+	private CalculateDetailGraduationUseCase calculateDetailGraduationUseCase;
+
+	@InjectMocks
+	private CalculateSingleDetailGraduationService calculateSingleDetailGraduationService;
+
+	@DisplayName("단일 카테고리 졸업상세결과를 조회한다.")
+	@ValueSource(strings =
+		{"COMMON_CULTURE", "CORE_CULTURE", "PRIMARY_MAJOR", "DUAL_MAJOR", "SUB_MAJOR",
+			"PRIMARY_BASIC_ACADEMICAL_CULTURE",
+			"DUAL_BASIC_ACADEMICAL_CULTURE"
+		})
+	@ParameterizedTest
+	void calculateSingleDetailGraduation(String graduationCategoryName) {
+		// given
+		User user = User.builder()
+			.id(1L)
+			.entryYear(19)
+			.primaryMajor("응용소프트웨어전공").build();
+		given(findUserUseCase.findUserById(user.getId())).willReturn(user);
+
+		TakenLectureInventory takenLectureInventory = TakenLectureInventory.from(new HashSet<>());
+		given(findTakenLectureUseCase.findTakenLectures(user.getId())).willReturn(
+			takenLectureInventory);
+
+		GraduationCategory graduationCategory = GraduationCategory.valueOf(graduationCategoryName);
+		given(calculateDetailGraduationUseCaseResolver.resolveCalculateDetailGraduationUseCase(
+			graduationCategory)).willReturn(calculateDetailGraduationUseCase);
+
+		// when
+		calculateSingleDetailGraduationService.calculateSingleDetailGraduation(
+			user.getId(), graduationCategory);
+
+		// then
+		then(calculateDetailGraduationUseCase).should()
+			.calculateDetailGraduation(any(User.class), any(TakenLectureInventory.class),
+				any(GraduationRequirement.class));
+
+	}
+
+}

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateSingleDetailGraduationServiceTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateSingleDetailGraduationServiceTest.java
@@ -14,7 +14,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.plzgraduate.myongjigraduatebe.graduation.api.CalculateDetailGraduationUseCaseResolver;
+import com.plzgraduate.myongjigraduatebe.graduation.support.resolver.CalculateDetailGraduationUseCaseResolver;
 import com.plzgraduate.myongjigraduatebe.graduation.application.usecase.CalculateDetailGraduationUseCase;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationRequirement;

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/support/WebAdaptorTestSupport.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/support/WebAdaptorTestSupport.java
@@ -24,7 +24,7 @@ import com.plzgraduate.myongjigraduatebe.completedcredit.application.usecase.Fin
 import com.plzgraduate.myongjigraduatebe.core.config.JpaAuditingConfig;
 import com.plzgraduate.myongjigraduatebe.core.config.QuerydslConfig;
 import com.plzgraduate.myongjigraduatebe.core.config.SecurityConfig;
-import com.plzgraduate.myongjigraduatebe.graduation.api.FindDetailGraduationsController;
+import com.plzgraduate.myongjigraduatebe.graduation.api.FindDetailGraduationController;
 import com.plzgraduate.myongjigraduatebe.graduation.application.usecase.CalculateGraduationUseCase;
 import com.plzgraduate.myongjigraduatebe.graduation.application.usecase.CalculateSingleDetailGraduationUseCase;
 import com.plzgraduate.myongjigraduatebe.lecture.api.SearchLectureController;
@@ -71,7 +71,7 @@ import com.plzgraduate.myongjigraduatebe.user.application.usecase.withdraw.WithD
 	SignUpController.class,
 	FindAuthIdController.class,
 	FindCompletedCreditsController.class,
-	FindDetailGraduationsController.class
+	FindDetailGraduationController.class
 })
 public abstract class WebAdaptorTestSupport {
 

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/support/WebAdaptorTestSupport.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/support/WebAdaptorTestSupport.java
@@ -24,7 +24,9 @@ import com.plzgraduate.myongjigraduatebe.completedcredit.application.usecase.Fin
 import com.plzgraduate.myongjigraduatebe.core.config.JpaAuditingConfig;
 import com.plzgraduate.myongjigraduatebe.core.config.QuerydslConfig;
 import com.plzgraduate.myongjigraduatebe.core.config.SecurityConfig;
+import com.plzgraduate.myongjigraduatebe.graduation.api.FindDetailGraduationsController;
 import com.plzgraduate.myongjigraduatebe.graduation.application.usecase.CalculateGraduationUseCase;
+import com.plzgraduate.myongjigraduatebe.graduation.application.usecase.CalculateSingleDetailGraduationUseCase;
 import com.plzgraduate.myongjigraduatebe.lecture.api.SearchLectureController;
 import com.plzgraduate.myongjigraduatebe.lecture.application.usecase.SearchLectureUseCase;
 import com.plzgraduate.myongjigraduatebe.parsing.api.ParsingTextController;
@@ -68,7 +70,8 @@ import com.plzgraduate.myongjigraduatebe.user.application.usecase.withdraw.WithD
 	ResetPasswordController.class,
 	SignUpController.class,
 	FindAuthIdController.class,
-	FindCompletedCreditsController.class
+	FindCompletedCreditsController.class,
+	FindDetailGraduationsController.class
 })
 public abstract class WebAdaptorTestSupport {
 
@@ -137,6 +140,9 @@ public abstract class WebAdaptorTestSupport {
 
 	@MockBean
 	protected FindCompletedCreditUseCase findCompletedCreditUseCase;
+
+	@MockBean
+	protected CalculateSingleDetailGraduationUseCase calculateSingleDetailGraduationUseCase;
 
 	@BeforeEach
 	void setUp() {


### PR DESCRIPTION
## Issue
Close. #248 

## ✅ 작업 내용
- 지난 번 논의한 내용과 이전 새로 구현한 CalculateDetailGraduationUseCaseResolver를 사용해 공통교양 상세 졸업 결과 조회 로직 구현

## 🤔 고민 했던 부분
- 조회 api에서 쿼리파라미터를 GraduationCategory 타입 변환 시 올바르지 않은 쿼리파라미터로 인해 타입 변환 에러 핸들링 시 직접 구현한 컨버터를 이용하더라도 결국 MethodArgumentTypeMismatchException까지 throw되어 우선 해당 Exception을 핸들링하도록 하였습니다.
-> 에러 메시지를 유연하게 사용하지 못함

- 추가로 지난번 의견 주셨던 쿼리 파라미터에 GraduationCategory Enum Type name을 노출시켜 api layer까지 도메인 모델이 보여지는 것보단 다른 문자열을 받아 타입 변환 하는 것이 좋아보인다는 의견을 주셨는데 아직 프론트분들과 해당 부분 논의된 것이 없어 추후 공유 후 변경하도록 하겠습니다!

## 🔊 도움이 필요한 부분!!
