### PR TITLE
[DEV-22] 주전공 상세 졸업 결과 조회 로직 분리 및 API 개발

### DIFF
--- a/.github/workflows/dn-rule.yml
+++ b/.github/workflows/dn-rule.yml
@@ -1,7 +1,7 @@
 name: PR Label Automation
 on:
   schedule:
-    - cron: '0 0 10 * *'
+    - cron: '0 10 * * *'
 
 jobs:
   update-labels:

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculatePrimaryElectiveMajorDetailGraduationService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculatePrimaryElectiveMajorDetailGraduationService.java
@@ -1,11 +1,9 @@
 package com.plzgraduate.myongjigraduatebe.graduation.application.service;
 
-import static com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory.PRIMARY_MAJOR;
-
-import org.springframework.stereotype.Service;
+import static com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory.PRIMARY_ELECTIVE_MAJOR;
 
 import com.plzgraduate.myongjigraduatebe.core.meta.UseCase;
-import com.plzgraduate.myongjigraduatebe.graduation.application.usecase.CalculatePrimaryMajorDetailGraduationUseCase;
+import com.plzgraduate.myongjigraduatebe.graduation.application.usecase.CalculatePrimaryElectiveMajorDetailGraduationUseCase;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailGraduationResult;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationRequirement;
@@ -13,10 +11,12 @@ import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureI
 import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
 
 @UseCase
-public class CalculatePrimaryMajorDetailGraduationService implements CalculatePrimaryMajorDetailGraduationUseCase {
+public class CalculatePrimaryElectiveMajorDetailGraduationService
+	implements CalculatePrimaryElectiveMajorDetailGraduationUseCase {
+
 	@Override
 	public boolean supports(GraduationCategory graduationCategory) {
-		return graduationCategory == PRIMARY_MAJOR;
+		return graduationCategory == PRIMARY_ELECTIVE_MAJOR;
 	}
 
 	@Override
@@ -24,4 +24,5 @@ public class CalculatePrimaryMajorDetailGraduationService implements CalculatePr
 		GraduationRequirement graduationRequirement) {
 		return null;
 	}
+
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculatePrimaryElectiveMajorDetailGraduationService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculatePrimaryElectiveMajorDetailGraduationService.java
@@ -43,18 +43,27 @@ public class CalculatePrimaryElectiveMajorDetailGraduationService
 		DetailGraduationResult majorDetailGraduationResult = majorGraduationManager.createDetailGraduationResult(user,
 			takenLectureInventory, graduationMajorLectures, graduationRequirement.getPrimaryMajorCredit());
 
-		return separateElectiveMajor(majorDetailGraduationResult);
+		DetailCategoryResult electiveMajorDetailCategoryResult = separateElectiveMajor(majorDetailGraduationResult);
+
+		return DetailGraduationResult.create(PRIMARY_ELECTIVE_MAJOR,
+			electiveMajorDetailCategoryResult.getTotalCredits(), List.of(electiveMajorDetailCategoryResult));
 	}
 
-	private static DetailGraduationResult separateElectiveMajor(
+	@Override
+	public DetailGraduationResult isolatePrimaryElectiveMajorDetailGraduation(
+		DetailGraduationResult detailPrimaryMajorGraduationResult) {
+		DetailCategoryResult electiveMajorDetailCategoryResult = separateElectiveMajor(
+			detailPrimaryMajorGraduationResult);
+		return DetailGraduationResult.create(PRIMARY_ELECTIVE_MAJOR,
+			electiveMajorDetailCategoryResult.getTotalCredits(), List.of(electiveMajorDetailCategoryResult));
+	}
+
+	private DetailCategoryResult separateElectiveMajor(
 		DetailGraduationResult majorDetailGraduationResult) {
-		DetailCategoryResult electiveMajorDetailCategoryResult = majorDetailGraduationResult.getDetailCategory()
+		return majorDetailGraduationResult.getDetailCategory()
 			.stream()
 			.filter(detailCategoryResult -> detailCategoryResult.getDetailCategoryName().equals("전공선택"))
 			.findFirst()
 			.orElseThrow(() -> new IllegalArgumentException("Not Found DetailCategoryResult(전공 선택)"));
-
-		return DetailGraduationResult.create(PRIMARY_ELECTIVE_MAJOR,
-			electiveMajorDetailCategoryResult.getTotalCredits(), List.of(electiveMajorDetailCategoryResult));
 	}
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculatePrimaryElectiveMajorDetailGraduationService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculatePrimaryElectiveMajorDetailGraduationService.java
@@ -2,17 +2,33 @@ package com.plzgraduate.myongjigraduatebe.graduation.application.service;
 
 import static com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory.PRIMARY_ELECTIVE_MAJOR;
 
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.transaction.annotation.Transactional;
+
 import com.plzgraduate.myongjigraduatebe.core.meta.UseCase;
 import com.plzgraduate.myongjigraduatebe.graduation.application.usecase.CalculatePrimaryElectiveMajorDetailGraduationUseCase;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailCategoryResult;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailGraduationResult;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationRequirement;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.service.GraduationManager;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.service.major.MajorManager;
+import com.plzgraduate.myongjigraduatebe.lecture.application.port.FindMajorPort;
+import com.plzgraduate.myongjigraduatebe.lecture.domain.model.MajorLecture;
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
 
+import lombok.RequiredArgsConstructor;
+
 @UseCase
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class CalculatePrimaryElectiveMajorDetailGraduationService
 	implements CalculatePrimaryElectiveMajorDetailGraduationUseCase {
+
+	private final FindMajorPort findMajorPort;
 
 	@Override
 	public boolean supports(GraduationCategory graduationCategory) {
@@ -22,7 +38,23 @@ public class CalculatePrimaryElectiveMajorDetailGraduationService
 	@Override
 	public DetailGraduationResult calculateDetailGraduation(User user, TakenLectureInventory takenLectureInventory,
 		GraduationRequirement graduationRequirement) {
-		return null;
+		Set<MajorLecture> graduationMajorLectures = findMajorPort.findMajor(user.getPrimaryMajor());
+		GraduationManager<MajorLecture> majorGraduationManager = new MajorManager();
+		DetailGraduationResult majorDetailGraduationResult = majorGraduationManager.createDetailGraduationResult(user,
+			takenLectureInventory, graduationMajorLectures, graduationRequirement.getPrimaryMajorCredit());
+
+		return separateElectiveMajor(majorDetailGraduationResult);
 	}
 
+	private static DetailGraduationResult separateElectiveMajor(
+		DetailGraduationResult majorDetailGraduationResult) {
+		DetailCategoryResult electiveMajorDetailCategoryResult = majorDetailGraduationResult.getDetailCategory()
+			.stream()
+			.filter(detailCategoryResult -> detailCategoryResult.getDetailCategoryName().equals("전공선택"))
+			.findFirst()
+			.orElseThrow(() -> new IllegalArgumentException("Not Found DetailCategoryResult(전공 선택)"));
+
+		return DetailGraduationResult.create(PRIMARY_ELECTIVE_MAJOR,
+			electiveMajorDetailCategoryResult.getTotalCredits(), List.of(electiveMajorDetailCategoryResult));
+	}
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculatePrimaryMandatoryMajorDetailGraduationService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculatePrimaryMandatoryMajorDetailGraduationService.java
@@ -1,0 +1,59 @@
+package com.plzgraduate.myongjigraduatebe.graduation.application.service;
+
+import static com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory.PRIMARY_MANDATORY_MAJOR;
+
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.transaction.annotation.Transactional;
+
+import com.plzgraduate.myongjigraduatebe.core.meta.UseCase;
+import com.plzgraduate.myongjigraduatebe.graduation.application.usecase.CalculatePrimaryMandatoryMajorDetailGraduationUseCase;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailCategoryResult;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailGraduationResult;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationRequirement;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.service.GraduationManager;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.service.major.MajorManager;
+import com.plzgraduate.myongjigraduatebe.lecture.application.port.FindMajorPort;
+import com.plzgraduate.myongjigraduatebe.lecture.domain.model.MajorLecture;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
+
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CalculatePrimaryMandatoryMajorDetailGraduationService
+	implements CalculatePrimaryMandatoryMajorDetailGraduationUseCase {
+
+	private final FindMajorPort findMajorPort;
+
+	@Override
+	public boolean supports(GraduationCategory graduationCategory) {
+		return graduationCategory == PRIMARY_MANDATORY_MAJOR;
+	}
+
+	@Override
+	public DetailGraduationResult calculateDetailGraduation(User user, TakenLectureInventory takenLectureInventory,
+		GraduationRequirement graduationRequirement) {
+		Set<MajorLecture> graduationMajorLectures = findMajorPort.findMajor(user.getPrimaryMajor());
+		GraduationManager<MajorLecture> majorGraduationManager = new MajorManager();
+		DetailGraduationResult majorDetailGraduationResult = majorGraduationManager.createDetailGraduationResult(user,
+			takenLectureInventory, graduationMajorLectures, graduationRequirement.getPrimaryMajorCredit());
+
+		return separateMandatoryMajor(majorDetailGraduationResult);
+	}
+
+	private static DetailGraduationResult separateMandatoryMajor(
+		DetailGraduationResult majorDetailGraduationResult) {
+		DetailCategoryResult majorMandatoryDetailCategoryResult = majorDetailGraduationResult.getDetailCategory().stream()
+			.filter(detailCategoryResult -> detailCategoryResult.getDetailCategoryName().equals("전공필수"))
+			.findFirst()
+			.orElseThrow(() -> new IllegalArgumentException("Not Found DetailCategoryResult(전공 필수)"));
+
+		return DetailGraduationResult.create(PRIMARY_MANDATORY_MAJOR,
+			majorMandatoryDetailCategoryResult.getTotalCredits(), List.of(majorMandatoryDetailCategoryResult));
+	}
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculatePrimaryMandatoryMajorDetailGraduationService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculatePrimaryMandatoryMajorDetailGraduationService.java
@@ -43,17 +43,25 @@ public class CalculatePrimaryMandatoryMajorDetailGraduationService
 		DetailGraduationResult majorDetailGraduationResult = majorGraduationManager.createDetailGraduationResult(user,
 			takenLectureInventory, graduationMajorLectures, graduationRequirement.getPrimaryMajorCredit());
 
-		return separateMandatoryMajor(majorDetailGraduationResult);
+		DetailCategoryResult mandatoryMajorDetailCategoryResult = separateMandatoryMajor(majorDetailGraduationResult);
+		return DetailGraduationResult.create(PRIMARY_MANDATORY_MAJOR,
+			mandatoryMajorDetailCategoryResult.getTotalCredits(), List.of(mandatoryMajorDetailCategoryResult));
 	}
 
-	private static DetailGraduationResult separateMandatoryMajor(
+	@Override
+	public DetailGraduationResult isolatePrimaryMandatoryMajorDetailGraduation(
+		DetailGraduationResult primaryMajorDetailGraduationResult) {
+		DetailCategoryResult mandatoryMajorDetailCategoryResult = separateMandatoryMajor(
+			primaryMajorDetailGraduationResult);
+		return DetailGraduationResult.create(PRIMARY_MANDATORY_MAJOR,
+			mandatoryMajorDetailCategoryResult.getTotalCredits(), List.of(mandatoryMajorDetailCategoryResult));
+	}
+
+	private DetailCategoryResult separateMandatoryMajor(
 		DetailGraduationResult majorDetailGraduationResult) {
-		DetailCategoryResult mandatoryMajorDetailCategoryResult = majorDetailGraduationResult.getDetailCategory().stream()
+		return majorDetailGraduationResult.getDetailCategory().stream()
 			.filter(detailCategoryResult -> detailCategoryResult.getDetailCategoryName().equals("전공필수"))
 			.findFirst()
 			.orElseThrow(() -> new IllegalArgumentException("Not Found DetailCategoryResult(전공 필수)"));
-
-		return DetailGraduationResult.create(PRIMARY_MANDATORY_MAJOR,
-			mandatoryMajorDetailCategoryResult.getTotalCredits(), List.of(mandatoryMajorDetailCategoryResult));
 	}
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculatePrimaryMandatoryMajorDetailGraduationService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculatePrimaryMandatoryMajorDetailGraduationService.java
@@ -48,12 +48,12 @@ public class CalculatePrimaryMandatoryMajorDetailGraduationService
 
 	private static DetailGraduationResult separateMandatoryMajor(
 		DetailGraduationResult majorDetailGraduationResult) {
-		DetailCategoryResult majorMandatoryDetailCategoryResult = majorDetailGraduationResult.getDetailCategory().stream()
+		DetailCategoryResult mandatoryMajorDetailCategoryResult = majorDetailGraduationResult.getDetailCategory().stream()
 			.filter(detailCategoryResult -> detailCategoryResult.getDetailCategoryName().equals("전공필수"))
 			.findFirst()
 			.orElseThrow(() -> new IllegalArgumentException("Not Found DetailCategoryResult(전공 필수)"));
 
 		return DetailGraduationResult.create(PRIMARY_MANDATORY_MAJOR,
-			majorMandatoryDetailCategoryResult.getTotalCredits(), List.of(majorMandatoryDetailCategoryResult));
+			mandatoryMajorDetailCategoryResult.getTotalCredits(), List.of(mandatoryMajorDetailCategoryResult));
 	}
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/usecase/CalculatePrimaryElectiveMajorDetailGraduationUseCase.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/usecase/CalculatePrimaryElectiveMajorDetailGraduationUseCase.java
@@ -1,4 +1,9 @@
 package com.plzgraduate.myongjigraduatebe.graduation.application.usecase;
 
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailGraduationResult;
+
 public interface CalculatePrimaryElectiveMajorDetailGraduationUseCase extends CalculateDetailGraduationUseCase {
+
+	DetailGraduationResult isolatePrimaryElectiveMajorDetailGraduation(
+		DetailGraduationResult primaryMajorDetailGraduationResult);
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/usecase/CalculatePrimaryElectiveMajorDetailGraduationUseCase.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/usecase/CalculatePrimaryElectiveMajorDetailGraduationUseCase.java
@@ -1,0 +1,4 @@
+package com.plzgraduate.myongjigraduatebe.graduation.application.usecase;
+
+public interface CalculatePrimaryElectiveMajorDetailGraduationUseCase extends CalculateDetailGraduationUseCase {
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/usecase/CalculatePrimaryMajorDetailGraduationUseCase.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/usecase/CalculatePrimaryMajorDetailGraduationUseCase.java
@@ -1,4 +1,0 @@
-package com.plzgraduate.myongjigraduatebe.graduation.application.usecase;
-
-public interface CalculatePrimaryMajorDetailGraduationUseCase extends CalculateDetailGraduationUseCase {
-}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/usecase/CalculatePrimaryMandatoryMajorDetailGraduationUseCase.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/usecase/CalculatePrimaryMandatoryMajorDetailGraduationUseCase.java
@@ -1,0 +1,4 @@
+package com.plzgraduate.myongjigraduatebe.graduation.application.usecase;
+
+public interface CalculatePrimaryMandatoryMajorDetailGraduationUseCase extends CalculateDetailGraduationUseCase {
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/usecase/CalculatePrimaryMandatoryMajorDetailGraduationUseCase.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/usecase/CalculatePrimaryMandatoryMajorDetailGraduationUseCase.java
@@ -1,4 +1,9 @@
 package com.plzgraduate.myongjigraduatebe.graduation.application.usecase;
 
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailGraduationResult;
+
 public interface CalculatePrimaryMandatoryMajorDetailGraduationUseCase extends CalculateDetailGraduationUseCase {
+
+	DetailGraduationResult isolatePrimaryMandatoryMajorDetailGraduation(
+		DetailGraduationResult primaryMajorDetailGraduationResult);
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/DetailCategoryResult.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/DetailCategoryResult.java
@@ -76,7 +76,7 @@ public class DetailCategoryResult {
 		int leftCredit = takenCredits - totalCredits;
 		if (leftCredit > 0) {
 			if (detailCategoryName.equals(PRIMARY_MANDATORY_MAJOR.getName()) ||
-				detailCategoryName.equals(PRIMARY_ELECTIVE_MAJOR)) {
+				detailCategoryName.equals(PRIMARY_ELECTIVE_MAJOR.getName())) {
 				freeElectiveLeftCredit = leftCredit;
 				takenCredits -= leftCredit;
 				return;

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/DetailCategoryResult.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/DetailCategoryResult.java
@@ -52,7 +52,7 @@ public class DetailCategoryResult {
 	public void calculate(Set<Lecture> taken, Set<Lecture> graduationLectures) {
 		addTakenLectures(taken);
 		calculateLeftCredit();
-		if(!checkCompleted()) {
+		if (!checkCompleted()) {
 			addMandatoryLectures(taken, graduationLectures);
 		}
 	}
@@ -75,7 +75,8 @@ public class DetailCategoryResult {
 	private void calculateLeftCredit() {
 		int leftCredit = takenCredits - totalCredits;
 		if (leftCredit > 0) {
-			if (detailCategoryName.equals(PRIMARY_MAJOR.getName())) {
+			if (detailCategoryName.equals(PRIMARY_MANDATORY_MAJOR.getName()) ||
+				detailCategoryName.equals(PRIMARY_ELECTIVE_MAJOR)) {
 				freeElectiveLeftCredit = leftCredit;
 				takenCredits -= leftCredit;
 				return;

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/DetailGraduationResult.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/DetailGraduationResult.java
@@ -15,7 +15,8 @@ public class DetailGraduationResult {
 	private final List<DetailCategoryResult> detailCategory;
 
 	@Builder
-	private DetailGraduationResult(GraduationCategory graduationCategory, boolean isCompleted, int totalCredit, int takenCredit,
+	private DetailGraduationResult(GraduationCategory graduationCategory, boolean isCompleted, int totalCredit,
+		int takenCredit,
 		List<DetailCategoryResult> detailCategory) {
 		this.graduationCategory = graduationCategory;
 		this.isCompleted = isCompleted;
@@ -28,6 +29,16 @@ public class DetailGraduationResult {
 		List<DetailCategoryResult> detailCategoryResults) {
 		return DetailGraduationResult.builder()
 			.graduationCategory(graduationCategory)
+			.isCompleted(checkIsCompleted(detailCategoryResults))
+			.totalCredit(totalCredit)
+			.takenCredit(calculateTakenCredit(detailCategoryResults))
+			.detailCategory(detailCategoryResults)
+			.build();
+	}
+
+	public static DetailGraduationResult createMajorDetailGraduationResult(int totalCredit,
+		List<DetailCategoryResult> detailCategoryResults) {
+		return DetailGraduationResult.builder()
 			.isCompleted(checkIsCompleted(detailCategoryResults))
 			.totalCredit(totalCredit)
 			.takenCredit(calculateTakenCredit(detailCategoryResults))

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/GraduationCategory.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/GraduationCategory.java
@@ -13,7 +13,8 @@ public enum GraduationCategory {
 
 	COMMON_CULTURE("공통교양"),
 	CORE_CULTURE("핵심교양"),
-	PRIMARY_MAJOR("주전공"),
+	PRIMARY_MANDATORY_MAJOR("주전공필수"),
+	PRIMARY_ELECTIVE_MAJOR("주전공선택"),
 	DUAL_MAJOR("복수전공"),
 	SUB_MAJOR("부전공"),
 	PRIMARY_BASIC_ACADEMICAL_CULTURE("주 학문기초교양"),

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/major/MajorManager.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/major/MajorManager.java
@@ -1,7 +1,5 @@
 package com.plzgraduate.myongjigraduatebe.graduation.domain.service.major;
 
-import static com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory.PRIMARY_MAJOR;
-
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -15,8 +13,8 @@ import com.plzgraduate.myongjigraduatebe.graduation.domain.service.major.excepti
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.Lecture;
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.MajorLecture;
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLecture;
-import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
 
 public class MajorManager implements GraduationManager<MajorLecture> {
 
@@ -50,7 +48,7 @@ public class MajorManager implements GraduationManager<MajorLecture> {
 		DetailCategoryResult electiveDetailCategoryResult = electiveMajorManager.createDetailCategoryResult(
 			takenLectureInventory, electiveLectures, electiveMajorTotalCredit);
 
-		return DetailGraduationResult.create(PRIMARY_MAJOR, graduationResultTotalCredit,
+		return DetailGraduationResult.createMajorDetailGraduationResult(graduationResultTotalCredit,
 			List.of(mandantoryDetailCategoryResult, electiveDetailCategoryResult));
 	}
 

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/lecture/domain/model/MajorLecture.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/lecture/domain/model/MajorLecture.java
@@ -13,7 +13,8 @@ public class MajorLecture {
 	private final int appliedEndEntryYear;
 
 	@Builder
-	private MajorLecture(Lecture lecture, String major, int isMandatory, int appliedStartEntryYear, int appliedEndEntryYear) {
+	private MajorLecture(Lecture lecture, String major, int isMandatory, int appliedStartEntryYear,
+		int appliedEndEntryYear) {
 		this.lecture = lecture;
 		this.major = major;
 		this.isMandatory = isMandatory;
@@ -21,7 +22,8 @@ public class MajorLecture {
 		this.appliedEndEntryYear = appliedEndEntryYear;
 	}
 
-	public static MajorLecture of(Lecture lecture, String major, int isMandatory, int appliedStartEntryYear, int appliedEndEntryYear) {
+	public static MajorLecture of(Lecture lecture, String major, int isMandatory, int appliedStartEntryYear,
+		int appliedEndEntryYear) {
 		return MajorLecture.builder()
 			.lecture(lecture)
 			.major(major)
@@ -32,13 +34,13 @@ public class MajorLecture {
 	}
 
 	public void changeMandatoryToElectiveByEntryYearRange(int entryYear) {
-		if(checkMandatoryByEntryYear(entryYear)) {
+		if (checkMandatoryByEntryYear(entryYear)) {
 			isMandatory = 0;
 		}
 	}
 
 	private boolean checkMandatoryByEntryYear(int entryYear) {
-		return isMandatory==1 && !(entryYear >= appliedStartEntryYear && entryYear <= appliedEndEntryYear);
+		return isMandatory == 1 && !(entryYear >= appliedStartEntryYear && entryYear <= appliedEndEntryYear);
 	}
 
 }

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/completedcredit/application/service/GenerateOrModifyCompletedCreditServiceTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/completedcredit/application/service/GenerateOrModifyCompletedCreditServiceTest.java
@@ -88,7 +88,9 @@ class GenerateOrModifyCompletedCreditServiceTest {
 					(double)eachDetailGraduationResultTakenCredit),
 				tuple(GraduationCategory.CORE_CULTURE, eachDetailGraduationResultTotalCredit,
 					(double)eachDetailGraduationResultTakenCredit),
-				tuple(GraduationCategory.PRIMARY_MAJOR, eachDetailGraduationResultTotalCredit,
+				tuple(GraduationCategory.PRIMARY_MANDATORY_MAJOR, eachDetailGraduationResultTotalCredit,
+					(double)eachDetailGraduationResultTakenCredit),
+				tuple(GraduationCategory.PRIMARY_ELECTIVE_MAJOR, eachDetailGraduationResultTotalCredit,
 					(double)eachDetailGraduationResultTakenCredit),
 				tuple(GraduationCategory.PRIMARY_BASIC_ACADEMICAL_CULTURE, eachDetailGraduationResultTotalCredit,
 					(double)eachDetailGraduationResultTakenCredit),
@@ -111,7 +113,12 @@ class GenerateOrModifyCompletedCreditServiceTest {
 				.takenCredit(takenCredit)
 				.build(),
 			DetailGraduationResult.builder()
-				.graduationCategory(GraduationCategory.PRIMARY_MAJOR)
+				.graduationCategory(GraduationCategory.PRIMARY_MANDATORY_MAJOR)
+				.totalCredit(totalCredit)
+				.takenCredit(takenCredit)
+				.build(),
+			DetailGraduationResult.builder()
+				.graduationCategory(GraduationCategory.PRIMARY_ELECTIVE_MAJOR)
 				.totalCredit(totalCredit)
 				.takenCredit(takenCredit)
 				.build(),

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/api/SingleCalculateDetailGraduationUseCaseResolverTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/api/SingleCalculateDetailGraduationUseCaseResolverTest.java
@@ -22,8 +22,8 @@ class SingleCalculateDetailGraduationUseCaseResolverTest {
 
 	@DisplayName("졸업 카테고리를 계산할 수 있는 CalculateDetailGraduationUseCaseResolver 반환한다.")
 	@ValueSource(strings =
-		{"COMMON_CULTURE", "CORE_CULTURE", "PRIMARY_MAJOR", "DUAL_MAJOR", "SUB_MAJOR",
-			"PRIMARY_BASIC_ACADEMICAL_CULTURE", "DUAL_BASIC_ACADEMICAL_CULTURE"
+		{"COMMON_CULTURE", "CORE_CULTURE", "PRIMARY_MANDATORY_MAJOR", "PRIMARY_ELECTIVE_MAJOR", "DUAL_MAJOR",
+			"SUB_MAJOR", "PRIMARY_BASIC_ACADEMICAL_CULTURE", "DUAL_BASIC_ACADEMICAL_CULTURE"
 		})
 	@ParameterizedTest
 	void resolveCalculateDetailGraduationUseCase(String graduationCategoryName) {

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculatePrimaryElectiveMajorDetailGraduationServiceTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculatePrimaryElectiveMajorDetailGraduationServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.junit.jupiter.api.DisplayName;
@@ -14,6 +15,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailCategoryResult;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailGraduationResult;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationRequirement;
 import com.plzgraduate.myongjigraduatebe.lecture.application.port.FindMajorPort;
@@ -70,6 +72,36 @@ class CalculatePrimaryElectiveMajorDetailGraduationServiceTest {
 		assertThat(detailPrimaryElectiveMajorGraduationResult)
 			.extracting("graduationCategory", "isCompleted", "totalCredit", "takenCredit")
 			.contains(PRIMARY_ELECTIVE_MAJOR, false, 67, 3.0);
+	}
+
+	@DisplayName("주전공 졸업결과에서 주전공선택 졸업결과를 분리한다.")
+	@Test
+	void isolatePrimaryElectiveMajorDetailGraduation() {
+		//given
+		DetailCategoryResult primaryMandatoryMajorDetailCategoryResult = DetailCategoryResult.builder()
+			.detailCategoryName("전공필수")
+			.totalCredits(18)
+			.takenCredits(18)
+			.build();
+		DetailCategoryResult primaryElectiveMajorDetailCategoryResult = DetailCategoryResult.builder()
+			.detailCategoryName("전공선택")
+			.totalCredits(52)
+			.takenCredits(52)
+			.build();
+		DetailGraduationResult primaryMajorDetailGraduationResult = DetailGraduationResult.createMajorDetailGraduationResult(
+			70, List.of(primaryMandatoryMajorDetailCategoryResult, primaryElectiveMajorDetailCategoryResult));
+
+		//when
+		DetailGraduationResult primaryElectiveMajorDetailGraduationResult = calculatePrimaryElectiveMajorDetailGraduationService.isolatePrimaryElectiveMajorDetailGraduation(
+			primaryMajorDetailGraduationResult);
+
+		//then
+		assertThat(primaryElectiveMajorDetailGraduationResult)
+			.extracting("graduationCategory", "totalCredit", "takenCredit")
+			.contains(
+				PRIMARY_ELECTIVE_MAJOR,
+				primaryElectiveMajorDetailCategoryResult.getTotalCredits(),
+				primaryElectiveMajorDetailCategoryResult.getTakenCredits());
 	}
 
 }

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculatePrimaryElectiveMajorDetailGraduationServiceTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculatePrimaryElectiveMajorDetailGraduationServiceTest.java
@@ -1,0 +1,75 @@
+package com.plzgraduate.myongjigraduatebe.graduation.application.service;
+
+import static com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory.PRIMARY_ELECTIVE_MAJOR;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailGraduationResult;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationRequirement;
+import com.plzgraduate.myongjigraduatebe.lecture.application.port.FindMajorPort;
+import com.plzgraduate.myongjigraduatebe.lecture.domain.model.Lecture;
+import com.plzgraduate.myongjigraduatebe.lecture.domain.model.MajorLecture;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLecture;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
+
+@ExtendWith(MockitoExtension.class)
+class CalculatePrimaryElectiveMajorDetailGraduationServiceTest {
+
+	@Mock
+	private FindMajorPort findMajorPort;
+	@InjectMocks
+	private CalculatePrimaryElectiveMajorDetailGraduationService calculatePrimaryElectiveMajorDetailGraduationService;
+
+	@DisplayName("유저의 주전공선택 상세 졸업결과를 계산한다.")
+	@Test
+	void calculateCoreCulture() {
+		//given
+		User user = User.builder()
+			.id(1L)
+			.primaryMajor("응용소프트웨어전공")
+			.entryYear(19).build();
+		HashSet<MajorLecture> graduationMajorLectures = new HashSet<>(
+			Set.of(
+				// 전공 필수
+				MajorLecture.of(Lecture.builder().lectureCode("HEC01211").credit(3).build(), "응용소프트웨어전공", 1, 16, 23),
+				// 전공 선택
+				MajorLecture.of(Lecture.builder().lectureCode("HEC01305").credit(3).build(), "응용소프트웨어전공", 0, 16, 23),
+				// 전공 선택
+				MajorLecture.of(Lecture.builder().lectureCode("HEC01318").credit(3).build(), "응용소프트웨어전공", 0, 16, 23)));
+		given(findMajorPort.findMajor(user.getPrimaryMajor())).willReturn(graduationMajorLectures);
+
+		HashSet<TakenLecture> takenLectures = new HashSet<>(
+			Set.of(
+				TakenLecture.builder().lecture(Lecture.builder()
+					.lectureCode("HEC01211") //전공 필수
+					.credit(3).build()).build(),
+				TakenLecture.builder().lecture(Lecture.builder()
+					.lectureCode("HEC01305") //전공 선택
+					.credit(3).build()).build()));
+		TakenLectureInventory takenLectureInventory = TakenLectureInventory.from(takenLectures);
+
+		GraduationRequirement graduationRequirement = GraduationRequirement.builder()
+			.primaryMajorCredit(70).build();
+
+		//when
+		DetailGraduationResult detailPrimaryElectiveMajorGraduationResult = calculatePrimaryElectiveMajorDetailGraduationService.calculateDetailGraduation(
+			user, takenLectureInventory, graduationRequirement);
+
+		//then
+		assertThat(detailPrimaryElectiveMajorGraduationResult)
+			.extracting("graduationCategory", "isCompleted", "totalCredit", "takenCredit")
+			.contains(PRIMARY_ELECTIVE_MAJOR, false, 67, 3.0);
+	}
+
+}

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculatePrimaryMandatoryMajorDetailGraduationServiceTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculatePrimaryMandatoryMajorDetailGraduationServiceTest.java
@@ -1,10 +1,12 @@
 package com.plzgraduate.myongjigraduatebe.graduation.application.service;
 
+import static com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory.PRIMARY_ELECTIVE_MAJOR;
 import static com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory.PRIMARY_MANDATORY_MAJOR;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.junit.jupiter.api.DisplayName;
@@ -14,6 +16,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailCategoryResult;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailGraduationResult;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationRequirement;
 import com.plzgraduate.myongjigraduatebe.lecture.application.port.FindMajorPort;
@@ -66,6 +69,36 @@ class CalculatePrimaryMandatoryMajorDetailGraduationServiceTest {
 		assertThat(detailPrimaryMandatoryMajorGraduationResult)
 			.extracting("graduationCategory", "isCompleted", "totalCredit", "takenCredit")
 			.contains(PRIMARY_MANDATORY_MAJOR, false, 6, 3.0);
+	}
+
+	@DisplayName("주전공 졸업결과에서 주전공필수 졸업결과를 분리한다.")
+	@Test
+	void isolatePrimaryElectiveMajorDetailGraduation() {
+		//given
+		DetailCategoryResult primaryMandatoryMajorDetailCategoryResult = DetailCategoryResult.builder()
+			.detailCategoryName("전공필수")
+			.totalCredits(18)
+			.takenCredits(18)
+			.build();
+		DetailCategoryResult primaryElectiveMajorDetailCategoryResult = DetailCategoryResult.builder()
+			.detailCategoryName("전공선택")
+			.totalCredits(52)
+			.takenCredits(52)
+			.build();
+		DetailGraduationResult primaryMajorDetailGraduationResult = DetailGraduationResult.createMajorDetailGraduationResult(
+			70, List.of(primaryMandatoryMajorDetailCategoryResult, primaryElectiveMajorDetailCategoryResult));
+
+		//when
+		DetailGraduationResult primaryMandatoryMajorDetailGraduationResult = calculatePrimaryMandatoryMajorDetailGraduationService.isolatePrimaryMandatoryMajorDetailGraduation(
+			primaryMajorDetailGraduationResult);
+
+		//then
+		assertThat(primaryMandatoryMajorDetailGraduationResult)
+			.extracting("graduationCategory", "totalCredit", "takenCredit")
+			.contains(
+				PRIMARY_MANDATORY_MAJOR,
+				primaryMandatoryMajorDetailCategoryResult.getTotalCredits(),
+				primaryMandatoryMajorDetailCategoryResult.getTakenCredits());
 	}
 
 }

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculatePrimaryMandatoryMajorDetailGraduationServiceTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculatePrimaryMandatoryMajorDetailGraduationServiceTest.java
@@ -1,6 +1,5 @@
 package com.plzgraduate.myongjigraduatebe.graduation.application.service;
 
-import static com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory.PRIMARY_ELECTIVE_MAJOR;
 import static com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory.PRIMARY_MANDATORY_MAJOR;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculatePrimaryMandatoryMajorDetailGraduationServiceTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculatePrimaryMandatoryMajorDetailGraduationServiceTest.java
@@ -31,7 +31,7 @@ class CalculatePrimaryMandatoryMajorDetailGraduationServiceTest {
 	@InjectMocks
 	private CalculatePrimaryMandatoryMajorDetailGraduationService calculatePrimaryMandatoryMajorDetailGraduationService;
 
-	@DisplayName("유저의 핵심교양 상세 졸업결과를 계산한다.")
+	@DisplayName("유저의 주전공필수 졸업결과를 계산한다.")
 	@Test
 	void calculateCoreCulture() {
 		//given

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculatePrimaryMandatoryMajorDetailGraduationServiceTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculatePrimaryMandatoryMajorDetailGraduationServiceTest.java
@@ -1,0 +1,71 @@
+package com.plzgraduate.myongjigraduatebe.graduation.application.service;
+
+import static com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory.PRIMARY_MANDATORY_MAJOR;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailGraduationResult;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationRequirement;
+import com.plzgraduate.myongjigraduatebe.lecture.application.port.FindMajorPort;
+import com.plzgraduate.myongjigraduatebe.lecture.domain.model.Lecture;
+import com.plzgraduate.myongjigraduatebe.lecture.domain.model.MajorLecture;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLecture;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
+
+@ExtendWith(MockitoExtension.class)
+class CalculatePrimaryMandatoryMajorDetailGraduationServiceTest {
+
+	@Mock
+	private FindMajorPort findMajorPort;
+	@InjectMocks
+	private CalculatePrimaryMandatoryMajorDetailGraduationService calculatePrimaryMandatoryMajorDetailGraduationService;
+
+	@DisplayName("유저의 핵심교양 상세 졸업결과를 계산한다.")
+	@Test
+	void calculateCoreCulture() {
+		//given
+		User user = User.builder()
+			.id(1L)
+			.primaryMajor("응용소프트웨어전공")
+			.entryYear(19).build();
+		HashSet<MajorLecture> graduationMajorLectures = new HashSet<>(
+			Set.of(
+				MajorLecture.of(Lecture.builder().lectureCode("HEC01211").credit(3).build(), "응용소프트웨어전공", 1, 16, 23),
+				MajorLecture.of(Lecture.builder().lectureCode("HEC01204").credit(3).build(), "응용소프트웨어전공", 1, 16, 23)));
+		given(findMajorPort.findMajor(user.getPrimaryMajor())).willReturn(graduationMajorLectures);
+
+		HashSet<TakenLecture> takenLectures = new HashSet<>(
+			Set.of(
+				TakenLecture.builder().lecture(Lecture.builder()
+					.lectureCode("HEC01211") //전공 필수
+					.credit(3).build()).build(),
+				TakenLecture.builder().lecture(Lecture.builder()
+					.lectureCode("HEC01305") //전공 선택
+					.credit(3).build()).build()));
+		TakenLectureInventory takenLectureInventory = TakenLectureInventory.from(takenLectures);
+
+		GraduationRequirement graduationRequirement = GraduationRequirement.builder()
+			.primaryMajorCredit(70).build();
+
+		//when
+		DetailGraduationResult detailPrimaryMandatoryMajorGraduationResult = calculatePrimaryMandatoryMajorDetailGraduationService.calculateDetailGraduation(
+			user, takenLectureInventory, graduationRequirement);
+
+		//then
+		assertThat(detailPrimaryMandatoryMajorGraduationResult)
+			.extracting("graduationCategory", "isCompleted", "totalCredit", "takenCredit")
+			.contains(PRIMARY_MANDATORY_MAJOR, false, 6, 3.0);
+	}
+
+}

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateSingleDetailGraduationServiceTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateSingleDetailGraduationServiceTest.java
@@ -41,9 +41,8 @@ CalculateSingleDetailGraduationServiceTest {
 
 	@DisplayName("단일 카테고리 졸업상세결과를 조회한다.")
 	@ValueSource(strings =
-		{"COMMON_CULTURE", "CORE_CULTURE", "PRIMARY_MAJOR", "DUAL_MAJOR", "SUB_MAJOR",
-			"PRIMARY_BASIC_ACADEMICAL_CULTURE",
-			"DUAL_BASIC_ACADEMICAL_CULTURE"
+		{"COMMON_CULTURE", "CORE_CULTURE", "PRIMARY_MANDATORY_MAJOR", "PRIMARY_ELECTIVE_MAJOR", "DUAL_MAJOR",
+			"SUB_MAJOR", "PRIMARY_BASIC_ACADEMICAL_CULTURE", "DUAL_BASIC_ACADEMICAL_CULTURE"
 		})
 	@ParameterizedTest
 	void calculateSingleDetailGraduation(String graduationCategoryName) {


### PR DESCRIPTION
## Issue
Close #256 

## ✅ 작업 내용
- 주전공 졸업 카테고리 분리 - 주전공 필수/선택
- 주전공 필수/선택 상세 졸업 결과 조회 API 개발
- 주전공 졸업 카테고리 분리에 따른 전공 졸업 상세결과 계산 로직 수정

## 🤔 고민 했던 부분
- 기존의 전공 필수와 전공 선택 상세 졸업 결과가 통합되어 잇던 주전공 졸업 카테고리를 분리함에 따라 졸업 상세결과 계산 로직을 수정하고자 했으나 전공선택 상세 졸업 결과는 전공필수에 상세 졸업결과와 아주 강하게 결합되어 있기 때문에(전공 필수 졸업 결과에 따라 전공 선택 졸업 결과가 달라짐) 새롭게 분리한 졸업카테고리를 바탕으로 DetailGraduationResult를 계산하기 어려운 상황이었습니다.
따라서 기존의 MajorManager에서 수행한 주전공 졸업 계산을 활용하여 DetailGraduationResult의 DetailCategoryResult(전공필수, 선택)을 각각 새롭게 DetailGraduationResult로 만들어내는 로직으로 구현하였습니다!

- CalculateGraduationService의 전체 졸업 계산 로직에서 주전공 필수/선택 계산 로직 분리 시 이전에 구현했던 공통교양, 핵심교양과 같이 CalculateDetailGraduationUseCase인터페이스에 책임을 두어 완전히 분리하고 싶었지만 해당 유스케이스의 MajorManager가 DetailGraduationResult를 계산하면서 takenLecture를 소모하기 때문에 완벽한 분리가 불가능하였습니다. 따라서 주전공 졸업 카테고리의 DetailGraduationResult 계산 로직은 CalculateGraduationService에 일부 남겨두었습니다.
## 🔊 도움이 필요한 부분!!
