### PR TITLE
[DEV-33] 복수전공 학문기초교양 졸업계산 로직 수정

### DIFF
--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/GraduationResult.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/GraduationResult.java
@@ -59,6 +59,10 @@ public class GraduationResult {
 			&& normalCultureGraduationResult.isCompleted() && freeElectiveGraduationResult.isCompleted();
 	}
 
+	public void deductDuplicatedCredit(int duplicatedCredit) {
+		this.takenCredit -= duplicatedCredit;
+	}
+
 	private void addUpTotalCredit(int originTotalCredit) {
 		int combinedScore = detailGraduationResults.stream()
 			.mapToInt(DetailGraduationResult::getTotalCredit)

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/lecture/application/port/FindBasicAcademicalCulturePort.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/lecture/application/port/FindBasicAcademicalCulturePort.java
@@ -3,8 +3,11 @@ package com.plzgraduate.myongjigraduatebe.lecture.application.port;
 import java.util.Set;
 
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.BasicAcademicalCultureLecture;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
 
 public interface FindBasicAcademicalCulturePort {
 
 	Set<BasicAcademicalCultureLecture> findBasicAcademicalCulture(String major);
+
+	Set<BasicAcademicalCultureLecture> findDuplicatedLecturesBetweenMajors(User user);
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/lecture/infrastructure/adapter/persistence/FindBasicAcademicalCulturePersistenceAdapter.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/lecture/infrastructure/adapter/persistence/FindBasicAcademicalCulturePersistenceAdapter.java
@@ -9,6 +9,7 @@ import com.plzgraduate.myongjigraduatebe.lecture.domain.model.BasicAcademicalCul
 import com.plzgraduate.myongjigraduatebe.lecture.infrastructure.adapter.persistence.mapper.LectureMapper;
 import com.plzgraduate.myongjigraduatebe.lecture.infrastructure.adapter.persistence.repository.BasicAcademicalCultureRepository;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.College;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
 
 import lombok.RequiredArgsConstructor;
 
@@ -26,4 +27,15 @@ public class FindBasicAcademicalCulturePersistenceAdapter implements FindBasicAc
 			.map(lectureMapper::mapToBasicAcademicalCultureLectureModel)
 			.collect(Collectors.toSet());
 	}
+
+	@Override
+	public Set<BasicAcademicalCultureLecture> findDuplicatedLecturesBetweenMajors(User user) {
+		College primaryMajorCollage = College.findBelongingCollege(user.getPrimaryMajor());
+		College dualMajorCollage = College.findBelongingCollege(user.getDualMajor());
+		return basicAcademicalCultureRepository.findAllDuplicatedTakenByCollages(user.getId(),
+				primaryMajorCollage.getName(), dualMajorCollage.getName()).stream()
+			.map(lectureMapper::mapToBasicAcademicalCultureLectureModel)
+			.collect(Collectors.toSet());
+	}
+
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/lecture/infrastructure/adapter/persistence/repository/BasicAcademicalCultureRepository.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/lecture/infrastructure/adapter/persistence/repository/BasicAcademicalCultureRepository.java
@@ -12,4 +12,14 @@ public interface BasicAcademicalCultureRepository extends JpaRepository<BasicAca
 
 	@Query("select bac from BasicAcademicalCultureLectureJpaEntity bac join fetch bac.lectureJpaEntity where bac.college = :college")
 	List<BasicAcademicalCultureLectureJpaEntity> findAllByCollege(@Param("college") String college);
+
+	@Query("SELECT pb " +
+		"FROM BasicAcademicalCultureLectureJpaEntity pb " +
+		"JOIN BasicAcademicalCultureLectureJpaEntity db ON pb.lectureJpaEntity.id = db.lectureJpaEntity.id " +
+		"JOIN TakenLectureJpaEntity tl ON pb.lectureJpaEntity.id = tl.lecture.id " +
+		"WHERE tl.user.id = :userId " +
+		"AND pb.college = :primary " +
+		"AND db.college = :dual")
+	List<BasicAcademicalCultureLectureJpaEntity> findAllDuplicatedTakenByCollages(@Param("userId") Long id,
+		@Param("primary") String primaryMajorCollage, @Param("dual") String dualMajorCollage);
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/takenlecture/domain/model/TakenLectureInventory.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/takenlecture/domain/model/TakenLectureInventory.java
@@ -1,8 +1,11 @@
 package com.plzgraduate.myongjigraduatebe.takenlecture.domain.model;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import com.plzgraduate.myongjigraduatebe.lecture.domain.model.Lecture;
 
 import lombok.Builder;
 
@@ -17,6 +20,10 @@ public class TakenLectureInventory {
 
 	public Set<TakenLecture> getTakenLectures() {
 		return Collections.unmodifiableSet(takenLecture);
+	}
+
+	public TakenLectureInventory copy() {
+		return TakenLectureInventory.from(new HashSet<>(takenLecture));
 	}
 
 	public Set<TakenLecture> getCultureLectures() {
@@ -35,12 +42,20 @@ public class TakenLectureInventory {
 		takenLecture.removeAll(finishedTakenLecture);
 	}
 
+	public void handleFinishedLectures(Set<Lecture> finishedBasicAcademicalCultureLecture) {
+		takenLecture.removeAll(
+			takenLecture.stream()
+				.filter(taken -> finishedBasicAcademicalCultureLecture.contains(taken.getLecture()))
+				.collect(Collectors.toSet())
+		);
+	}
+
 	public int calculateTotalCredit() {
 		int totalCredit = this.takenLecture
 			.stream()
 			.mapToInt(takenLecture -> takenLecture.getLecture().getCredit())
 			.sum();
-		if(checkChapelCountIsFour(this.takenLecture)) {
+		if (checkChapelCountIsFour(this.takenLecture)) {
 			totalCredit += 2;
 		}
 		return totalCredit;

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/lecture/infrastructure/adapter/persistence/repository/BasicAcademicalCultureLectureRepositoryTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/lecture/infrastructure/adapter/persistence/repository/BasicAcademicalCultureLectureRepositoryTest.java
@@ -1,24 +1,32 @@
 package com.plzgraduate.myongjigraduatebe.lecture.infrastructure.adapter.persistence.repository;
 
+import static com.plzgraduate.myongjigraduatebe.user.domain.model.College.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import com.plzgraduate.myongjigraduatebe.lecture.infrastructure.adapter.persistence.entity.BasicAcademicalCultureLectureJpaEntity;
 import com.plzgraduate.myongjigraduatebe.lecture.infrastructure.adapter.persistence.entity.LectureJpaEntity;
-import com.plzgraduate.myongjigraduatebe.lecture.infrastructure.adapter.persistence.repository.BasicAcademicalCultureRepository;
-import com.plzgraduate.myongjigraduatebe.lecture.infrastructure.adapter.persistence.repository.LectureRepository;
 import com.plzgraduate.myongjigraduatebe.support.PersistenceTestSupport;
+import com.plzgraduate.myongjigraduatebe.takenlecture.infrastructure.adapter.persistence.TakenLectureRepository;
+import com.plzgraduate.myongjigraduatebe.takenlecture.infrastructure.adapter.persistence.entity.TakenLectureJpaEntity;
+import com.plzgraduate.myongjigraduatebe.user.infrastructure.adapter.persistence.entity.UserJpaEntity;
+import com.plzgraduate.myongjigraduatebe.user.infrastructure.adapter.persistence.repository.UserRepository;
 
 class BasicAcademicalCultureLectureRepositoryTest extends PersistenceTestSupport {
 
 	@Autowired
 	private LectureRepository lectureRepository;
+	@Autowired
+	private UserRepository userRepository;
+	@Autowired
+	private TakenLectureRepository takenLectureRepository;
 	@Autowired
 	private BasicAcademicalCultureRepository basicAcademicalCultureRepository;
 
@@ -43,6 +51,55 @@ class BasicAcademicalCultureLectureRepositoryTest extends PersistenceTestSupport
 		//then
 		assertThat(basicAcademicalCultureJpaEntities).extracting("college")
 			.contains(college);
+	}
+
+	@DisplayName("유저가 수강한 과목 중 유저의 주전공, 복수전공 양쪽 모두에 해당하는 학문기초교양의 수를 조회한다.")
+	@Test
+	void findAllDuplicatedTakenCountByCollages() {
+		//given
+		UserJpaEntity userJpaEntity = userRepository.save(UserJpaEntity.builder()
+			.authId("test")
+			.password("test")
+			.studentNumber("12341234")
+			.major("응용소프트웨어전공")
+			.dualMajor("경영학과").build());
+
+		LectureJpaEntity lectureJpaEntityA = LectureJpaEntity.builder()
+			.lectureCode("TESTA").build();
+		LectureJpaEntity lectureJpaEntityB = LectureJpaEntity.builder()
+			.lectureCode("TESTB").build();
+		List<LectureJpaEntity> lectureJpaEntities = lectureRepository.saveAll(
+			List.of(lectureJpaEntityA, lectureJpaEntityB));
+
+		TakenLectureJpaEntity takenLectureJpaEntityA = TakenLectureJpaEntity.builder()
+			.user(userJpaEntity)
+			.lecture(lectureJpaEntities.get(0))
+			.build();
+		TakenLectureJpaEntity takenLectureJpaEntityB = TakenLectureJpaEntity.builder()
+			.user(userJpaEntity)
+			.lecture(lectureJpaEntities.get(1))
+			.build();
+		takenLectureRepository.saveAll(List.of(takenLectureJpaEntityA, takenLectureJpaEntityB));
+
+		BasicAcademicalCultureLectureJpaEntity ictBasicAcademicalCultureJpaEntity = BasicAcademicalCultureLectureJpaEntity.builder()
+			.lectureJpaEntity(lectureJpaEntities.get(0))
+			.college(ICT.getName()).build();
+		BasicAcademicalCultureLectureJpaEntity businessBasicAcademicalCultureJpaEntity = BasicAcademicalCultureLectureJpaEntity.builder()
+			.lectureJpaEntity(lectureJpaEntities.get(1))
+			.college(BUSINESS.getName()).build();
+		BasicAcademicalCultureLectureJpaEntity bothBasicAcademicalCultureJpaEntity = BasicAcademicalCultureLectureJpaEntity.builder()
+			.lectureJpaEntity(lectureJpaEntities.get(0))
+			.college(BUSINESS.getName()).build();
+		basicAcademicalCultureRepository.saveAll(
+			List.of(ictBasicAcademicalCultureJpaEntity, businessBasicAcademicalCultureJpaEntity,
+				bothBasicAcademicalCultureJpaEntity));
+
+		//when
+		List<BasicAcademicalCultureLectureJpaEntity> duplicatedTakenBasicAcademicalCultures = basicAcademicalCultureRepository.findAllDuplicatedTakenByCollages(
+			userJpaEntity.getId(), ICT.getName(), BUSINESS.getName());
+
+		//then
+		assertThat(duplicatedTakenBasicAcademicalCultures).hasSize(1);
 	}
 
 	private List<BasicAcademicalCultureLectureJpaEntity> createBasicAcademicalCultures(

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/takenlecture/domain/model/TakenLectureInventoryTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/takenlecture/domain/model/TakenLectureInventoryTest.java
@@ -1,6 +1,6 @@
 package com.plzgraduate.myongjigraduatebe.takenlecture.domain.model;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashSet;
 import java.util.Map;
@@ -18,36 +18,23 @@ class TakenLectureInventoryTest {
 
 	private final User user = UserFixture.경영학과_19학번_ENG34();
 	private final Map<String, Lecture> mockLectureMap = LectureFixture.getMockLectureMap();
-	private final TakenLectureInventory takenLectureInventory = TakenLectureInventory.from(new HashSet<>(Set.of(
-		TakenLecture.of(user, mockLectureMap.get("KMA00101"), 2019, Semester.FIRST),
-		TakenLecture.of(user, mockLectureMap.get("KMA02102"), 2019, Semester.FIRST),
-		TakenLecture.of(user, mockLectureMap.get("KMA02122"), 2019, Semester.FIRST),
-		TakenLecture.of(user, mockLectureMap.get("KMA02104"), 2023, Semester.FIRST),
-		TakenLecture.of(user, mockLectureMap.get("KMA02141"), 2023, Semester.FIRST),
-		TakenLecture.of(user, mockLectureMap.get("KMA02106"), 2023, Semester.FIRST),
-		TakenLecture.of(user, mockLectureMap.get("KMA02107"), 2023, Semester.FIRST),
-		TakenLecture.of(user, mockLectureMap.get("KMA02123"), 2023, Semester.FIRST),
-		TakenLecture.of(user, mockLectureMap.get("KMA02124"), 2023, Semester.FIRST),
-		TakenLecture.of(user, mockLectureMap.get("KMA02108"), 2023, Semester.FIRST),
-		TakenLecture.of(user, mockLectureMap.get("KMA02109"), 2023, Semester.FIRST),
-		TakenLecture.of(user, mockLectureMap.get("KMA02125"), 2023, Semester.FIRST),
-		TakenLecture.of(user, mockLectureMap.get("KMA02126"), 2023, Semester.FIRST)
-	)));
 
 	@DisplayName("수강과목 목록에서 교양 수강과목 목록을 반환한다.")
 	@Test
 	void getTakenCultureLectures() {
 		//given //when
+		TakenLectureInventory takenLectureInventory = getTakenLectureInventory();
 		Set<TakenLecture> cultureLectures = takenLectureInventory.getCultureLectures();
 
 		//then
 		assertThat(cultureLectures).hasSize(takenLectureInventory.getTakenLectures().size());
 	}
 
-	@DisplayName("수강과목 목록에서 처리 완료된 과목을 제거한다.")
+	@DisplayName("수강과목 목록에서 처리 완료된 수강과목들을 제거한다.")
 	@Test
 	void handleFinishedTakenLectures() {
 		//given
+		TakenLectureInventory takenLectureInventory = getTakenLectureInventory();
 		int beforeHandleSize = takenLectureInventory.getTakenLectures().size();
 		Set<TakenLecture> finishedTakenLecture = new HashSet<>(Set.of(
 			TakenLecture.of(user, mockLectureMap.get("KMA00101"), 2019, Semester.FIRST),
@@ -83,5 +70,42 @@ class TakenLectureInventoryTest {
 
 		//then
 		assertThat(calculatedCredit).isEqualTo(4);
+	}
+
+	@DisplayName("수강과목 목록에서 처리 완료된 과목을 제거한다.")
+	@Test
+	void handleFinishedLectures() {
+		//given
+		TakenLectureInventory takenLectureInventory = getTakenLectureInventory();
+		int beforeHandleSize = takenLectureInventory.getTakenLectures().size();
+		Set<Lecture> finishedLectures = new HashSet<>(Set.of(
+			mockLectureMap.get("KMA00101"),
+			mockLectureMap.get("KMA02102")
+		));
+
+		//when
+		takenLectureInventory.handleFinishedLectures(finishedLectures);
+
+		//then
+		assertThat(takenLectureInventory.getTakenLectures())
+			.hasSize(beforeHandleSize - finishedLectures.size());
+	}
+
+	private TakenLectureInventory getTakenLectureInventory() {
+		return TakenLectureInventory.from(new HashSet<>(Set.of(
+			TakenLecture.of(user, mockLectureMap.get("KMA00101"), 2019, Semester.FIRST),
+			TakenLecture.of(user, mockLectureMap.get("KMA02102"), 2019, Semester.FIRST),
+			TakenLecture.of(user, mockLectureMap.get("KMA02122"), 2019, Semester.FIRST),
+			TakenLecture.of(user, mockLectureMap.get("KMA02104"), 2023, Semester.FIRST),
+			TakenLecture.of(user, mockLectureMap.get("KMA02141"), 2023, Semester.FIRST),
+			TakenLecture.of(user, mockLectureMap.get("KMA02106"), 2023, Semester.FIRST),
+			TakenLecture.of(user, mockLectureMap.get("KMA02107"), 2023, Semester.FIRST),
+			TakenLecture.of(user, mockLectureMap.get("KMA02123"), 2023, Semester.FIRST),
+			TakenLecture.of(user, mockLectureMap.get("KMA02124"), 2023, Semester.FIRST),
+			TakenLecture.of(user, mockLectureMap.get("KMA02108"), 2023, Semester.FIRST),
+			TakenLecture.of(user, mockLectureMap.get("KMA02109"), 2023, Semester.FIRST),
+			TakenLecture.of(user, mockLectureMap.get("KMA02125"), 2023, Semester.FIRST),
+			TakenLecture.of(user, mockLectureMap.get("KMA02126"), 2023, Semester.FIRST)
+		)));
 	}
 }


### PR DESCRIPTION
## Issue
Close #268 

## ✅ 작업 내용
- 복수전공생 학문기초교양 졸업계산 로직 수정 및 추가 작성

## 🤔 고민 했던 부분
- 복수전공 유저의 경우 학문기초 교양에 추가 요구사항이 존재했습니다. 주전공, 복수전공 모두에 해당하는 학문기초교양을 수강 시 두 학문기초교양 GraduationResult에 반영해야 하며, GraduationResult에 반영 후 해당 유저의 takenCredit에는 1번만 반영되어야 했습니다.
하지만 기존에 구현된 로직 상 주전공 학문기초교양을 계산시 TakenLectureInventory에서 공통과목이 소모되어 이후 계산하는 복수전공 학문기초교양 졸업계산에 포함이 안되었습니다.
이를 해결하기 위해 학문기초교양을 계산하는 시점의 TakenLectureInventory를 복제해 주전공, 복수전공 학문기초교양을 계산 후 원본 TakenLectureInventory에 소모된 takenLecture를 반영하도록 하였습니다.

## 🔊 도움이 필요한 부분!!
