### PR TITLE
[DEV-38] 회원탈퇴 오류 수정

### DIFF
--- a/src/main/java/com/plzgraduate/myongjigraduatebe/completedcredit/application/port/DeleteCompletedCreditPort.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/completedcredit/application/port/DeleteCompletedCreditPort.java
@@ -1,0 +1,8 @@
+package com.plzgraduate.myongjigraduatebe.completedcredit.application.port;
+
+import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
+
+public interface DeleteCompletedCreditPort {
+
+	void deleteAllCompletedCredits(User user);
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/completedcredit/infrastructure/persistence/DeletedCompletedCreditAdapter.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/completedcredit/infrastructure/persistence/DeletedCompletedCreditAdapter.java
@@ -1,0 +1,25 @@
+package com.plzgraduate.myongjigraduatebe.completedcredit.infrastructure.persistence;
+
+import org.springframework.transaction.annotation.Transactional;
+
+import com.plzgraduate.myongjigraduatebe.completedcredit.application.port.DeleteCompletedCreditPort;
+import com.plzgraduate.myongjigraduatebe.completedcredit.infrastructure.persistence.repository.CompletedCreditRepository;
+import com.plzgraduate.myongjigraduatebe.core.meta.PersistenceAdapter;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
+import com.plzgraduate.myongjigraduatebe.user.infrastructure.adapter.persistence.mapper.UserMapper;
+
+import lombok.RequiredArgsConstructor;
+
+@PersistenceAdapter
+@Transactional
+@RequiredArgsConstructor
+public class DeletedCompletedCreditAdapter implements DeleteCompletedCreditPort {
+
+	private final CompletedCreditRepository completedCreditRepository;
+	private final UserMapper userMapper;
+
+	@Override
+	public void deleteAllCompletedCredits(User user) {
+		completedCreditRepository.deleteAllByUserJpaEntity(userMapper.mapToJpaEntity(user));
+	}
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/completedcredit/infrastructure/persistence/repository/CompletedCreditRepository.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/completedcredit/infrastructure/persistence/repository/CompletedCreditRepository.java
@@ -11,4 +11,6 @@ public interface CompletedCreditRepository extends JpaRepository<CompletedCredit
 
 	List<CompletedCreditJpaEntity> findAllByUserJpaEntity(UserJpaEntity userJpaEntity);
 
+	void deleteAllByUserJpaEntity(UserJpaEntity userJpaEntity);
+
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/application/service/withdraw/WithDrawUserService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/application/service/withdraw/WithDrawUserService.java
@@ -3,6 +3,7 @@ package com.plzgraduate.myongjigraduatebe.user.application.service.withdraw;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.plzgraduate.myongjigraduatebe.completedcredit.application.port.DeleteCompletedCreditPort;
 import com.plzgraduate.myongjigraduatebe.core.meta.UseCase;
 import com.plzgraduate.myongjigraduatebe.parsing.application.port.DeleteParsingTextHistoryPort;
 import com.plzgraduate.myongjigraduatebe.takenlecture.application.usecase.delete.DeleteTakenLectureUseCase;
@@ -22,6 +23,7 @@ class WithDrawUserService implements WithDrawUserUseCase {
 	private final DeleteTakenLectureUseCase deleteTakenLectureByUserUseCase;
 	private final DeleteParsingTextHistoryPort deleteParsingTextHistoryPort;
 	private final DeleteUserPort deleteUserPort;
+	private final DeleteCompletedCreditPort deleteCompletedCreditPort;
 	private final PasswordEncoder passwordEncoder;
 
 	@Override
@@ -30,6 +32,7 @@ class WithDrawUserService implements WithDrawUserUseCase {
 		user.matchPassword(passwordEncoder, password);
 		deleteTakenLectureByUserUseCase.deleteAllTakenLecturesByUser(user);
 		deleteParsingTextHistoryPort.deleteUserParsingTextHistory(user);
+		deleteCompletedCreditPort.deleteAllCompletedCredits(user);
 		deleteUserPort.deleteUser(user);
 	}
 }

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/completedcredit/infrastructure/persistence/repository/CompletedCreditRepositoryTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/completedcredit/infrastructure/persistence/repository/CompletedCreditRepositoryTest.java
@@ -1,8 +1,9 @@
 package com.plzgraduate.myongjigraduatebe.completedcredit.infrastructure.persistence.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.List;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -50,9 +51,43 @@ class CompletedCreditRepositoryTest extends PersistenceTestSupport {
 			userJpaEntity);
 
 		//then
-		Assertions.assertThat(foundCompletedCredits).hasSize(2)
+		assertThat(foundCompletedCredits).hasSize(2)
 			.extracting("userJpaEntity.authId")
 			.contains(userJpaEntity.getAuthId());
+	}
+
+	@DisplayName("유저의 모든 이수학점 내역을 삭제한다.")
+	@Test
+	void deleteAllByUserJpaEntity() {
+	    //given
+		UserJpaEntity userJpaEntity = UserJpaEntity.builder()
+			.authId("test1234")
+			.password("test")
+			.studentNumber("60191112").build();
+		userRepository.save(userJpaEntity);
+
+		CompletedCreditJpaEntity commonCultureCompletedCreditJpaEntity = CompletedCreditJpaEntity.builder()
+			.userJpaEntity(userJpaEntity)
+			.graduationCategory(GraduationCategory.COMMON_CULTURE)
+			.totalCredit(10)
+			.takenCredit(10).build();
+
+		CompletedCreditJpaEntity coreCultureCompletedCreditJpaEntity = CompletedCreditJpaEntity.builder()
+			.userJpaEntity(userJpaEntity)
+			.graduationCategory(GraduationCategory.CORE_CULTURE)
+			.totalCredit(10)
+			.takenCredit(10).build();
+
+		completedCreditRepository.saveAll(
+			List.of(commonCultureCompletedCreditJpaEntity, coreCultureCompletedCreditJpaEntity));
+
+	    //when
+		completedCreditRepository.deleteAllByUserJpaEntity(userJpaEntity);
+
+	    //then
+		List<CompletedCreditJpaEntity> foundCompletedCredits = completedCreditRepository.findAllByUserJpaEntity(
+			userJpaEntity);
+	    assertThat(foundCompletedCredits).isEmpty();
 	}
 
 }

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/user/application/service/withdraw/WithDrawUserServiceTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/user/application/service/withdraw/WithDrawUserServiceTest.java
@@ -14,6 +14,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import com.plzgraduate.myongjigraduatebe.completedcredit.application.port.DeleteCompletedCreditPort;
 import com.plzgraduate.myongjigraduatebe.parsing.application.port.DeleteParsingTextHistoryPort;
 import com.plzgraduate.myongjigraduatebe.takenlecture.application.usecase.delete.DeleteTakenLectureUseCase;
 import com.plzgraduate.myongjigraduatebe.user.application.port.DeleteUserPort;
@@ -31,6 +32,8 @@ class WithDrawUserServiceTest {
 	private DeleteParsingTextHistoryPort deleteParsingTextHistoryPort;
 	@Mock
 	private DeleteUserPort deleteUserPort;
+	@Mock
+	private DeleteCompletedCreditPort deleteCompletedCreditPort;
 	@Mock
 	private PasswordEncoder passwordEncoder;
 
@@ -53,6 +56,7 @@ class WithDrawUserServiceTest {
 	    withDrawUserService.withDraw(user.getId(), password);
 		then(deleteTakenLectureByUserUseCase).should().deleteAllTakenLecturesByUser(user);
 		then(deleteParsingTextHistoryPort).should().deleteUserParsingTextHistory(user);
+		then(deleteCompletedCreditPort).should().deleteAllCompletedCredits(user);
 		then(deleteUserPort).should().deleteUser(user);
 	}
 


### PR DESCRIPTION
## Issue
Close #277

## ✅ 작업 내용
- 회원 탈퇴시 user 테이블과 completed_credit 테이블의 외래키 제약 조건때문에 회원탈퇴 시 발생하는 오류를 수정하였습니다.
- WitDrawUserService에서 회원정보 삭제 로직 전 user의 모든 completedCredit 삭제 로직 추가
- DeleteCompletedCreditPort 구현
   - deleteAllCompletedCredits()

## 🤔 고민 했던 부분

## 🔊 도움이 필요한 부분!!
