### PR TITLE
[DEV-53] 교환학생 인정학점 추가

### DIFF
--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateBasicAcademicalCultureGraduationService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateBasicAcademicalCultureGraduationService.java
@@ -77,6 +77,9 @@ public class CalculateBasicAcademicalCultureGraduationService implements
 				copiedTakenLectureForDualBasicAcademicalCulture,
 				graduationRequirement
 			);
+
+			addExchangeCreditsToDualBasicAcademicalCulture(user, dualBasicAcademicalCultureDetailGraduationResult);
+
 			syncOriginalTakenLectureInventory(
 				takenLectureInventory,
 				primaryBasicAcademicalCultureDetailGraduationResult,
@@ -90,6 +93,11 @@ public class CalculateBasicAcademicalCultureGraduationService implements
 		DetailGraduationResult primaryBasicAcademicalCultureGraduationResult = calculateSingleDetailGraduation(
 			user, PRIMARY_BASIC_ACADEMICAL_CULTURE, takenLectureInventory, graduationRequirement);
 		return List.of(primaryBasicAcademicalCultureGraduationResult);
+	}
+
+	private void addExchangeCreditsToDualBasicAcademicalCulture(User user, DetailGraduationResult dualBasicAcademicalCultureDetailGraduationResult) {
+		int additionalCredits = user.getExchangeCredit().getDualBasicAcademicalCulture();
+		dualBasicAcademicalCultureDetailGraduationResult.addCredit(additionalCredits);
 	}
 
 	private GraduationManager<BasicAcademicalCultureLecture> determineBasicAcademicalCultureGraduationManager(

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateMajorGraduationService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateMajorGraduationService.java
@@ -116,6 +116,9 @@ public class CalculateMajorGraduationService implements CalculateDetailGraduatio
 				DUAL_MANDATORY_MAJOR, dualMajorDetailGraduationResult);
 			DetailGraduationResult dualElectiveMajorDetailGraduationResult = isolateElectiveMajorDetailGraduation(
 				DUAL_ELECTIVE_MAJOR, dualMajorDetailGraduationResult);
+
+			addExchangeCreditsToDualElectiveMajor(user, dualElectiveMajorDetailGraduationResult);
+			
 			majorGraduationResults.addAll(
 				List.of(
 					dualMandatoryMajorDetailGraduationResult,
@@ -123,12 +126,25 @@ public class CalculateMajorGraduationService implements CalculateDetailGraduatio
 				));
 		}
 		if (user.getStudentCategory() == StudentCategory.SUB_MAJOR) {
-			majorGraduationResults.add(
-				generateSubMajorDetailGraduationResult(user, takenLectureInventory,
-					graduationRequirement
-				));
+			DetailGraduationResult subMajorDetailGraduationResult = generateSubMajorDetailGraduationResult(
+					user, takenLectureInventory, graduationRequirement
+			);
+
+			processExchangeCreditsForSubMajor(user, subMajorDetailGraduationResult);
+			majorGraduationResults.add(subMajorDetailGraduationResult);
 		}
 		return majorGraduationResults;
+	}
+
+	private void processExchangeCreditsForSubMajor(User user, DetailGraduationResult subMajorDetailGraduationResult) {
+		int exchangeCredit = user.getExchangeCredit().getSubMajor();
+		subMajorDetailGraduationResult.addCredit(exchangeCredit);
+
+	}
+
+	private void addExchangeCreditsToDualElectiveMajor(User user, DetailGraduationResult dualElectiveMajorDetailGraduationResult) {
+		int additionalCredits = user.getExchangeCredit().getDualMajor();
+		dualElectiveMajorDetailGraduationResult.addCredit(additionalCredits);
 	}
 
 	private DetailGraduationResult generateMajorDetailGraduationResult(

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/DetailCategoryResult.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/DetailCategoryResult.java
@@ -125,6 +125,7 @@ public class DetailCategoryResult {
 	}
 	public void addTakenCredits(int credits) {
 		this.takenCredits += credits;
+		checkCompleted();
 	}
 
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/FreeElectiveGraduationResult.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/FreeElectiveGraduationResult.java
@@ -53,10 +53,16 @@ public class FreeElectiveGraduationResult {
 			.sum();
 
 		int transferFreeElectiveCredit = calculateTransferFreeElectiveCredit(user);
+		int exchangeFreeElectiveCredit = calculateExchangeFreeElectiveCredit(user);
 
 		return remainCreditByDetailGraduationResult + remainCreditByTakenLectures
-			+ leftNormalCultureCredit+transferFreeElectiveCredit;
+			+ leftNormalCultureCredit+transferFreeElectiveCredit+exchangeFreeElectiveCredit;
 	}
+
+	private static int calculateExchangeFreeElectiveCredit(User user) {
+			return user.getExchangeCredit().getFreeElective();
+    }
+
 	private static int calculateTransferFreeElectiveCredit(User user) {
 		if (user.getStudentCategory() == StudentCategory.TRANSFER) {
 			return user.getTransferCredit().getFreeElective();

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/GraduationResult.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/GraduationResult.java
@@ -104,8 +104,9 @@ public class GraduationResult {
 	) {
 		int acknowledgedCredit = 0;
 		if (isTransferStudent(user)) {
-			acknowledgedCredit = user.getTransferCredit().getNormalCulture();
+			acknowledgedCredit += user.getTransferCredit().getNormalCulture();
 		}
+			acknowledgedCredit += user.getExchangeCredit().getNormalCulture();
 		this.normalCultureGraduationResult = NormalCultureGraduationResult.create(
 			graduationRequirement.getNormalCultureCredit(),
 			acknowledgedCredit,

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/basicacademicalculture/BusinessBasicAcademicalGraduationManager.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/basicacademicalculture/BusinessBasicAcademicalGraduationManager.java
@@ -66,11 +66,13 @@ public class BusinessBasicAcademicalGraduationManager implements BasicAcademical
 					taken.add(takenLecture.getLecture());
 				});
 		takenLectureInventory.handleFinishedTakenLectures(finishedTakenLecture);
+		int exchangeCredit = user.getExchangeCredit().getBasicAcademicalCulture();
 
 		DetailCategoryResult detailCategoryResult = DetailCategoryResult.create(
 				"학문기초교양", true, basicAcademicalCredit);
 		detailCategoryResult.calculate(taken, basicAcademicalLectures);
-
+		detailCategoryResult.addTakenCredits(exchangeCredit);
+		
 		return DetailGraduationResult.createNonCategorizedGraduationResult(basicAcademicalCredit,
 				List.of(detailCategoryResult));
 	}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/basicacademicalculture/DefaultBasicAcademicalGraduationManager.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/basicacademicalculture/DefaultBasicAcademicalGraduationManager.java
@@ -53,9 +53,12 @@ public class DefaultBasicAcademicalGraduationManager implements BasicAcademicalG
 			});
 		takenLectureInventory.handleFinishedTakenLectures(finishedTakenLecture);
 
+		int exchangeCredit = user.getExchangeCredit().getBasicAcademicalCulture();
+
 		DetailCategoryResult detailCategoryResult = DetailCategoryResult.create(
 			"학문기초교양", true, basicAcademicalCredit);
 		detailCategoryResult.calculate(taken, basicAcademicalLectures);
+		detailCategoryResult.addTakenCredits(exchangeCredit);
 
 		return DetailGraduationResult.createNonCategorizedGraduationResult(basicAcademicalCredit,
 			List.of(detailCategoryResult));

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/basicacademicalculture/SocialScienceBasicAcademicGraduationManager.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/basicacademicalculture/SocialScienceBasicAcademicGraduationManager.java
@@ -65,9 +65,11 @@ public class SocialScienceBasicAcademicGraduationManager implements
 			});
 		takenLectureInventory.handleFinishedTakenLectures(finishedTakenLecture);
 
+		int exchangeCredit = user.getExchangeCredit().getBasicAcademicalCulture();
 		DetailCategoryResult detailCategoryResult = DetailCategoryResult.create(
 			"학문기초교양", true, basicAcademicalCredit);
 		detailCategoryResult.calculate(taken, basicAcademicalLectures);
+		detailCategoryResult.addTakenCredits(exchangeCredit);
 
 		return DetailGraduationResult.createNonCategorizedGraduationResult(basicAcademicalCredit,
 			List.of(detailCategoryResult));

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/major/ElectiveMajorManager.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/major/ElectiveMajorManager.java
@@ -42,12 +42,19 @@ public class ElectiveMajorManager {
 			true, electiveMajorTotalCredit
 		);
 		processTransferStudent(user, electiveMajorResult);
+		processExchangeStudent(user, electiveMajorResult);
 
 		excludePracticeLectureForHaveToLecture(electiveLectures);
 		electiveMajorResult.calculate(takenElective, electiveLectures);
 		takenLectureInventory.handleFinishedTakenLectures(finishedTakenLecture);
 		return electiveMajorResult;
 	}
+
+	private void processExchangeStudent(User user, DetailCategoryResult electiveMajorResult) {
+			int exchangeCredit = user.getExchangeCredit().getMajor();
+			electiveMajorResult.addTakenCredits(exchangeCredit);
+	}
+
 	private void processTransferStudent(User user, DetailCategoryResult electiveMajorResult) {
 		if (user.getStudentCategory() == StudentCategory.TRANSFER) {
 			int transferCredit = user.getTransferCredit().getMajorLecture();

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/application/service/ParsingAnonymousService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/application/service/ParsingAnonymousService.java
@@ -31,20 +31,21 @@ public class ParsingAnonymousService implements ParsingAnonymousUseCase {
 
 
 		User anonymous = User.createAnonymous(
-			englishLevel,
-			parsingInformation.getStudentName(),
-			parsingInformation.getStudentNumber(),
-			parsingInformation.getMajor(),
-			parsingInformation.getSubMajor(),
-			parsingInformation.getDualMajor(),
-			parsingInformation.getAssociatedMajor(),
-			parsingInformation.getStudentCategory(),
-			parsingInformation.getTransferCredit()
+				englishLevel,
+				parsingInformation.getStudentName(),
+				parsingInformation.getStudentNumber(),
+				parsingInformation.getMajor(),
+				parsingInformation.getSubMajor(),
+				parsingInformation.getDualMajor(),
+				parsingInformation.getAssociatedMajor(),
+				parsingInformation.getStudentCategory(),
+				parsingInformation.getTransferCredit(),
+				parsingInformation.getExchangeCredit()
 		);
 
 		TakenLectureInventory takenLectureInventory = getTakenLectureInventory(
-			anonymous,
-			parsingInformation.getTakenLectureInformation()
+				anonymous,
+				parsingInformation.getTakenLectureInformation()
 		);
 
 		return new ParsingAnonymousDto(anonymous, takenLectureInventory);
@@ -63,18 +64,18 @@ public class ParsingAnonymousService implements ParsingAnonymousUseCase {
 	}
 
 	private TakenLectureInventory getTakenLectureInventory(
-		User anonymous,
-		List<ParsingTakenLectureDto> parsingTakenLectureDtoList
+			User anonymous,
+			List<ParsingTakenLectureDto> parsingTakenLectureDtoList
 	) {
 		Set<TakenLecture> takenLectures = parsingTakenLectureDtoList.stream()
-			.map(parsingTakenLectureDto -> TakenLecture.of(
-					anonymous,
-					Lecture.from(parsingTakenLectureDto.getLectureCode()),
-					parsingTakenLectureDto.getYear(),
-					parsingTakenLectureDto.getSemester()
+				.map(parsingTakenLectureDto -> TakenLecture.of(
+								anonymous,
+								Lecture.from(parsingTakenLectureDto.getLectureCode()),
+								parsingTakenLectureDto.getYear(),
+								parsingTakenLectureDto.getSemester()
+						)
 				)
-			)
-			.collect(Collectors.toSet());
+				.collect(Collectors.toSet());
 
 		return TakenLectureInventory.from(takenLectures);
 	}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/domain/ParsingInformation.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/domain/ParsingInformation.java
@@ -1,6 +1,7 @@
 package com.plzgraduate.myongjigraduatebe.parsing.domain;
 
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.Semester;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.ExchangeCredit;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.StudentCategory;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -23,21 +24,22 @@ public class ParsingInformation {
 	private final String dualMajor;
 	private final String associatedMajor;
 	private final TransferCredit transferCredit;
+	private final ExchangeCredit exchangeCredit;
 	private final StudentCategory studentCategory;
 	private final List<ParsingTakenLectureDto> takenLectureInformation;
 
 	@Builder
 	public ParsingInformation(
-		String studentName,
-		String studentNumber,
-		String major,
-		String changeMajor,
-		String subMajor,
-		String dualMajor,
-		String associatedMajor,
-		StudentCategory studentCategory,
-		TransferCredit transferCredit,
-		List<ParsingTakenLectureDto> takenLectureInformation
+			String studentName,
+			String studentNumber,
+			String major,
+			String changeMajor,
+			String subMajor,
+			String dualMajor,
+			String associatedMajor,
+			StudentCategory studentCategory,
+			TransferCredit transferCredit, ExchangeCredit exchangeCredit,
+			List<ParsingTakenLectureDto> takenLectureInformation
 	) {
 		this.studentName = studentName;
 		this.studentNumber = studentNumber;
@@ -48,6 +50,7 @@ public class ParsingInformation {
 		this.associatedMajor = associatedMajor;
 		this.studentCategory = studentCategory;
 		this.transferCredit = transferCredit;
+		this.exchangeCredit = exchangeCredit;
 		this.takenLectureInformation = takenLectureInformation;
 	}
 
@@ -56,14 +59,15 @@ public class ParsingInformation {
 		ParsingStudentCategoryDto parsingStudentCategoryDto = parseStudentCategory(splitText);
 
 		return ParsingInformation.builder().studentName(parseStudentName(splitText))
-			.studentNumber(parseStudentNumber(splitText)).major(parseMajor(splitText))
-			.dualMajor(parsingStudentCategoryDto.getDualMajor())
-			.changeMajor(parsingStudentCategoryDto.getChangeMajor())
-			.subMajor(parsingStudentCategoryDto.getSubMajor())
-			.associatedMajor(parsingStudentCategoryDto.getAssociatedMajor())
-			.studentCategory(parsingStudentCategoryDto.getStudentCategory())
-			.transferCredit(parsingStudentCategoryDto.getTransferCredit())
-			.takenLectureInformation(parseTakenLectureInformation(splitText)).build();
+				.studentNumber(parseStudentNumber(splitText)).major(parseMajor(splitText))
+				.dualMajor(parsingStudentCategoryDto.getDualMajor())
+				.changeMajor(parsingStudentCategoryDto.getChangeMajor())
+				.subMajor(parsingStudentCategoryDto.getSubMajor())
+				.associatedMajor(parsingStudentCategoryDto.getAssociatedMajor())
+				.studentCategory(parsingStudentCategoryDto.getStudentCategory())
+				.transferCredit(parsingStudentCategoryDto.getTransferCredit())
+				.exchangeCredit(parsingStudentCategoryDto.getExchangeCredit())
+				.takenLectureInformation(parseTakenLectureInformation(splitText)).build();
 	}
 
 	private static String[] splitParsingText(String parsingText) {
@@ -94,9 +98,11 @@ public class ParsingInformation {
 		String associatedMajor = null;
 		StudentCategory studentCategory;
 		TransferCredit transferCredit;
+		ExchangeCredit exchangeCredit;
 		String secondLineText = splitText[2];
 		String thirdLineText = splitText[3];
 		String fourthLineText = splitText[4];
+		String fifthLineText = splitText[5];
 		List<String> categories = new ArrayList<>();
 		String[] parts = secondLineText.split(", ");
 		String[] thirdLineParts = thirdLineText.split(", ");
@@ -122,14 +128,20 @@ public class ParsingInformation {
 				categories.add("편입");
 			}
 		}
+
 		studentCategory = StudentCategory.from(categories);
 		String fourthLine = fourthLineText.substring("편입생 인정학점 - ".length());
 		transferCredit = TransferCredit.from(Arrays.stream(fourthLine.split(","))
 				.map(s -> s.replaceAll("\\D", ""))
 				.collect(Collectors.joining("/")));
 
+		String fifthLine = fifthLineText.substring("교환학생 인정학점 - ".length());
+		exchangeCredit = ExchangeCredit.from(Arrays.stream(fifthLine.split(","))
+				.map(s -> s.replaceAll("\\D", ""))
+				.collect(Collectors.joining("/")));
+
 		return ParsingStudentCategoryDto.of(
-				changeMajor, subMajor, dualMajor, associatedMajor, studentCategory, transferCredit
+				changeMajor, subMajor, dualMajor, associatedMajor, studentCategory, transferCredit, exchangeCredit
 		);
 	}
 
@@ -137,8 +149,8 @@ public class ParsingInformation {
 		List<ParsingTakenLectureDto> takenLectureInformation = new ArrayList<>();
 		for (int i = 16; i < splitText.length; i += 7) {
 			if (i + 3 < splitText.length && !Pattern.matches(
-				"^[A-Z]+$",
-				splitText[i + 3].substring(0, 1)
+					"^[A-Z]+$",
+					splitText[i + 3].substring(0, 1)
 			)) {
 				return takenLectureInformation;
 			}
@@ -148,9 +160,9 @@ public class ParsingInformation {
 			char grade = splitText[i + 6].charAt(0);
 			if (grade != 'F' && grade != 'N' && grade != 'R') {
 				takenLectureInformation.add(ParsingTakenLectureDto.of(
-					code,
-					year,
-					Semester.of(semester)
+						code,
+						year,
+						Semester.of(semester)
 				));
 			}
 			if (i + 7 < splitText.length && Character.isDigit(splitText[i + 7].charAt(0))) {

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/domain/ParsingInformation.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/domain/ParsingInformation.java
@@ -38,7 +38,8 @@ public class ParsingInformation {
 			String dualMajor,
 			String associatedMajor,
 			StudentCategory studentCategory,
-			TransferCredit transferCredit, ExchangeCredit exchangeCredit,
+			TransferCredit transferCredit,
+			ExchangeCredit exchangeCredit,
 			List<ParsingTakenLectureDto> takenLectureInformation
 	) {
 		this.studentName = studentName;
@@ -129,7 +130,7 @@ public class ParsingInformation {
 			}
 		}
 
-		studentCategory = StudentCategory.from(categories);
+
 		String fourthLine = fourthLineText.substring("편입생 인정학점 - ".length());
 		transferCredit = TransferCredit.from(Arrays.stream(fourthLine.split(","))
 				.map(s -> s.replaceAll("\\D", ""))
@@ -140,6 +141,7 @@ public class ParsingInformation {
 				.map(s -> s.replaceAll("\\D", ""))
 				.collect(Collectors.joining("/")));
 
+		studentCategory = StudentCategory.from(categories);
 		return ParsingStudentCategoryDto.of(
 				changeMajor, subMajor, dualMajor, associatedMajor, studentCategory, transferCredit, exchangeCredit
 		);

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/domain/ParsingStudentCategoryDto.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/domain/ParsingStudentCategoryDto.java
@@ -1,5 +1,6 @@
 package com.plzgraduate.myongjigraduatebe.parsing.domain;
 
+import com.plzgraduate.myongjigraduatebe.user.domain.model.ExchangeCredit;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.StudentCategory;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.TransferCredit;
 import lombok.Builder;
@@ -14,16 +15,18 @@ class ParsingStudentCategoryDto {
 	private final String associatedMajor;
 	private final StudentCategory studentCategory;
 	private final TransferCredit transferCredit;
+	private final ExchangeCredit exchangeCredit;
 
 
 	@Builder
 	private ParsingStudentCategoryDto(
-		String changeMajor,
-		String dualMajor,
-		String subMajor,
-		String associatedMajor,
-		StudentCategory studentCategory,
-		TransferCredit transferCredit
+			String changeMajor,
+			String dualMajor,
+			String subMajor,
+			String associatedMajor,
+			StudentCategory studentCategory,
+			TransferCredit transferCredit,
+			ExchangeCredit exchangeCredit
 	) {
 		this.changeMajor = changeMajor;
 		this.dualMajor = dualMajor;
@@ -31,23 +34,26 @@ class ParsingStudentCategoryDto {
 		this.associatedMajor = associatedMajor;
 		this.studentCategory = studentCategory;
 		this.transferCredit = transferCredit;
+		this.exchangeCredit = exchangeCredit;
 	}
 
 	public static ParsingStudentCategoryDto of(
-		String changeMajor,
-		String subMajor,
-		String dualMajor,
-		String associatedMajor,
-		StudentCategory studentCategory,
-		TransferCredit transferCredit
+			String changeMajor,
+			String subMajor,
+			String dualMajor,
+			String associatedMajor,
+			StudentCategory studentCategory,
+			TransferCredit transferCredit,
+			ExchangeCredit exchangeCredit
 	) {
 		return ParsingStudentCategoryDto.builder()
-			.changeMajor(changeMajor)
-			.dualMajor(dualMajor)
-			.subMajor(subMajor)
-			.associatedMajor(associatedMajor)
-			.studentCategory(studentCategory)
-			.transferCredit(transferCredit)
-			.build();
+				.changeMajor(changeMajor)
+				.dualMajor(dualMajor)
+				.subMajor(subMajor)
+				.associatedMajor(associatedMajor)
+				.studentCategory(studentCategory)
+				.transferCredit(transferCredit)
+				.exchangeCredit(exchangeCredit)
+				.build();
 	}
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/application/service/update/UpdateStudentInformationService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/application/service/update/UpdateStudentInformationService.java
@@ -25,6 +25,7 @@ class UpdateStudentInformationService implements UpdateStudentInformationUseCase
 			updateStudentInformationCommand.getAssociatedMajor(),
 			updateStudentInformationCommand.getStudentCategory(),
 			updateStudentInformationCommand.getTransferCredit(),
+			updateStudentInformationCommand.getExchangeCredit(),
 			updateStudentInformationCommand.getTotalCredit(),
 			updateStudentInformationCommand.getTakenCredit(),
 			updateStudentInformationCommand.isGraduate()

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/application/usecase/update/UpdateStudentInformationCommand.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/application/usecase/update/UpdateStudentInformationCommand.java
@@ -2,6 +2,7 @@ package com.plzgraduate.myongjigraduatebe.user.application.usecase.update;
 
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationResult;
 import com.plzgraduate.myongjigraduatebe.parsing.domain.ParsingInformation;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.ExchangeCredit;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.StudentCategory;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.TransferCredit;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
@@ -11,7 +12,8 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class UpdateStudentInformationCommand {
+public class
+UpdateStudentInformationCommand {
 
 	private User user;
 
@@ -27,6 +29,8 @@ public class UpdateStudentInformationCommand {
 
 	private TransferCredit transferCredit;
 
+	private ExchangeCredit exchangeCredit;
+
 	private StudentCategory studentCategory;
 
 	private int totalCredit;
@@ -37,8 +41,8 @@ public class UpdateStudentInformationCommand {
 
 	@Builder
 	private UpdateStudentInformationCommand(User user, String name, String major, String dualMajor,
-		String subMajor, String associatedMajor,  TransferCredit transferCredit, StudentCategory studentCategory, int totalCredit, double takenCredit,
-		boolean graduate) {
+											String subMajor, String associatedMajor, TransferCredit transferCredit, ExchangeCredit exchangeCredit, StudentCategory studentCategory, int totalCredit, double takenCredit,
+											boolean graduate) {
 		this.user = user;
 		this.name = name;
 		this.major = major;
@@ -46,6 +50,7 @@ public class UpdateStudentInformationCommand {
 		this.subMajor = subMajor;
 		this.associatedMajor = associatedMajor;
 		this.transferCredit = transferCredit;
+		this.exchangeCredit = exchangeCredit;
 		this.studentCategory = studentCategory;
 		this.totalCredit = totalCredit;
 		this.takenCredit = takenCredit;
@@ -53,32 +58,33 @@ public class UpdateStudentInformationCommand {
 	}
 
 	public static UpdateStudentInformationCommand of(User user,
-		ParsingInformation parsingInformation) {
+													 ParsingInformation parsingInformation) {
 		return UpdateStudentInformationCommand.builder()
-			.user(user)
-			.name(parsingInformation.getStudentName())
-			.major(parsingInformation.getMajor())
-			.dualMajor(parsingInformation.getDualMajor())
-			.subMajor(parsingInformation.getSubMajor())
-			.associatedMajor(parsingInformation.getAssociatedMajor())
-			.transferCredit(parsingInformation.getTransferCredit())
-			.studentCategory(parsingInformation.getStudentCategory())
-			.build();
+				.user(user)
+				.name(parsingInformation.getStudentName())
+				.major(parsingInformation.getMajor())
+				.dualMajor(parsingInformation.getDualMajor())
+				.subMajor(parsingInformation.getSubMajor())
+				.associatedMajor(parsingInformation.getAssociatedMajor())
+				.transferCredit(parsingInformation.getTransferCredit())
+				.exchangeCredit(parsingInformation.getExchangeCredit())
+				.studentCategory(parsingInformation.getStudentCategory())
+				.build();
 	}
 
 	public static UpdateStudentInformationCommand update(User user,
-		GraduationResult graduationResult) {
+														 GraduationResult graduationResult) {
 		return UpdateStudentInformationCommand.builder()
-			.user(user)
-			.name(user.getName())
-			.studentCategory(user.getStudentCategory())
-			.major(user.getPrimaryMajor())
-			.dualMajor(user.getDualMajor())
-			.subMajor(user.getSubMajor())
-			.associatedMajor(user.getAssociatedMajor())
-			.totalCredit(graduationResult.getTotalCredit())
-			.takenCredit(graduationResult.getTakenCredit())
-			.graduate(graduationResult.isGraduated())
-			.build();
+				.user(user)
+				.name(user.getName())
+				.studentCategory(user.getStudentCategory())
+				.major(user.getPrimaryMajor())
+				.dualMajor(user.getDualMajor())
+				.subMajor(user.getSubMajor())
+				.associatedMajor(user.getAssociatedMajor())
+				.totalCredit(graduationResult.getTotalCredit())
+				.takenCredit(graduationResult.getTakenCredit())
+				.graduate(graduationResult.isGraduated())
+				.build();
 	}
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/domain/model/ExchangeCredit.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/domain/model/ExchangeCredit.java
@@ -47,6 +47,12 @@ public class ExchangeCredit {
         return input.matches("^\\d+/\\d+/\\d+/\\d+/\\d+/\\d+/\\d+/\\d+$");
     }
 
+    public boolean hasExchange() {
+        return basicAcademicalCulture != 0 || normalCulture != 0 || major != 0 ||
+                dualBasicAcademicalCulture != 0 || dualMajor != 0 || fusionMajor != 0 ||
+                subMajor != 0 || freeElective != 0;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/domain/model/ExchangeCredit.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/domain/model/ExchangeCredit.java
@@ -47,12 +47,6 @@ public class ExchangeCredit {
         return input.matches("^\\d+/\\d+/\\d+/\\d+/\\d+/\\d+/\\d+/\\d+$");
     }
 
-    public boolean hasExchange() {
-        return basicAcademicalCulture != 0 || normalCulture != 0 || major != 0 ||
-                dualBasicAcademicalCulture != 0 || dualMajor != 0 || fusionMajor != 0 ||
-                subMajor != 0 || freeElective != 0;
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/domain/model/ExchangeCredit.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/domain/model/ExchangeCredit.java
@@ -1,0 +1,86 @@
+package com.plzgraduate.myongjigraduatebe.user.domain.model;
+
+import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExchangeCredit {
+
+    private int basicAcademicalCulture;  // 학문기초교양
+    private int normalCulture;          // 일반교양
+    private int major;                  // 전공
+    private int dualBasicAcademicalCulture; // 복수전공학문기초교양
+    private int dualMajor;              // 복수전공
+    private int fusionMajor;            // 융합전공
+    private int subMajor;               // 부전공
+    private int freeElective;           // 자유선택
+
+    public static ExchangeCredit empty() {
+        return new ExchangeCredit(0, 0, 0, 0, 0, 0, 0, 0);
+    }
+
+    public static ExchangeCredit from(String input) {
+        if (isValid(input)) {
+            String[] parts = input.split("/");
+            int basicAcademicalCulture = Integer.parseInt(parts[0]);
+            int normalCulture = Integer.parseInt(parts[1]);
+            int major = Integer.parseInt(parts[2]);
+            int dualBasicAcademicalCulture = Integer.parseInt(parts[3]);
+            int dualMajor = Integer.parseInt(parts[4]);
+            int fusionMajor = Integer.parseInt(parts[5]);
+            int subMajor = Integer.parseInt(parts[6]);
+            int freeElective = Integer.parseInt(parts[7]);
+
+            return new ExchangeCredit(basicAcademicalCulture, normalCulture, major,
+                    dualBasicAcademicalCulture, dualMajor, fusionMajor, subMajor, freeElective);
+        } else {
+            throw new IllegalArgumentException("잘못된 형식입니다.");
+        }
+    }
+
+    private static boolean isValid(String input) {
+        // 8개의 숫자가 '/'로 구분된 형식인지 확인
+        return input.matches("^\\d+/\\d+/\\d+/\\d+/\\d+/\\d+/\\d+/\\d+$");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ExchangeCredit that = (ExchangeCredit) o;
+        return basicAcademicalCulture == that.basicAcademicalCulture &&
+                normalCulture == that.normalCulture &&
+                major == that.major &&
+                dualBasicAcademicalCulture == that.dualBasicAcademicalCulture &&
+                dualMajor == that.dualMajor &&
+                fusionMajor == that.fusionMajor &&
+                subMajor == that.subMajor &&
+                freeElective == that.freeElective;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(basicAcademicalCulture, normalCulture, major,
+                dualBasicAcademicalCulture, dualMajor, fusionMajor, subMajor, freeElective);
+    }
+
+    @Override
+    public String toString() {
+        return basicAcademicalCulture + "/"
+                + normalCulture + "/"
+                + major + "/"
+                + dualBasicAcademicalCulture + "/"
+                + dualMajor + "/"
+                + fusionMajor + "/"
+                + subMajor + "/"
+                + freeElective;
+    }
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/domain/model/User.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/domain/model/User.java
@@ -22,6 +22,7 @@ public class User {
 	private final Instant createdAt;
 	private final Instant updatedAt;
 	private TransferCredit transferCredit;
+	private ExchangeCredit exchangeCredit;
 	private String password;
 	private String name;
 	private String primaryMajor;
@@ -47,6 +48,7 @@ public class User {
             String dualMajor,
             String associatedMajor,
 			TransferCredit transferCredit,
+			ExchangeCredit exchangeCredit,
 			StudentCategory studentCategory,
             int totalCredit,
             double takenCredit,
@@ -67,6 +69,7 @@ public class User {
 		this.associatedMajor = associatedMajor;
 		this.studentCategory = studentCategory;
 		this.transferCredit = transferCredit != null ? transferCredit : TransferCredit.empty();
+		this.exchangeCredit = exchangeCredit != null ? exchangeCredit : ExchangeCredit.empty();
 		this.totalCredit = totalCredit;
 		this.takenCredit = takenCredit;
 		this.graduated = graduated;
@@ -95,7 +98,9 @@ public class User {
 		String dualMajor,
 		String associatedMajor,
 		StudentCategory studentCategory,
-        TransferCredit transferCredit) {
+        TransferCredit transferCredit,
+		ExchangeCredit exchangeCredit) {
+
 		return User.builder()
 			.authId("anonymous")
 			.name(name)
@@ -111,6 +116,7 @@ public class User {
 			.takenCredit(0)
 			.graduated(false)
 			.transferCredit(transferCredit)
+			.exchangeCredit(exchangeCredit)
 			.build();
 	}
 
@@ -135,6 +141,7 @@ public class User {
 			", dualMajor='" + dualMajor + '\'' +
 			", associatedMajor='" + associatedMajor + '\'' +
 			", transferCredit=" + transferCredit +
+			", exchangeCredit=" + exchangeCredit +
 			", studentCategory=" + studentCategory +
 			", totalCredit=" + totalCredit +
 			", takenCredit=" + takenCredit +
@@ -145,7 +152,7 @@ public class User {
 	public void updateStudentInformation(
 		String name, String major, String dualMajor,
 		String subMajor, String associatedMajor,
-		StudentCategory studentCategory, TransferCredit transferCredit, int totalCredit, double takenCredit, boolean graduate
+		StudentCategory studentCategory, TransferCredit transferCredit,  ExchangeCredit exchangeCredit, int totalCredit, double takenCredit, boolean graduate
 	) {
 		this.name = name;
 		this.primaryMajor = major;
@@ -154,6 +161,7 @@ public class User {
 		this.associatedMajor = associatedMajor;
 		this.studentCategory = studentCategory;
 		updateTransferCredit(transferCredit);
+		updateExchangeCredit(exchangeCredit);
 		this.totalCredit = totalCredit;
 		this.takenCredit = takenCredit;
 		this.graduated = graduate;
@@ -162,6 +170,11 @@ public class User {
 	private void updateTransferCredit(TransferCredit transferCredit) {
 		if (transferCredit != null) {
 			this.transferCredit = transferCredit;
+		}
+	}
+	private void updateExchangeCredit(ExchangeCredit exchangeCredit) {
+		if (exchangeCredit != null) {
+			this.exchangeCredit = exchangeCredit;
 		}
 	}
 	public boolean checkBeforeEntryYear(int entryYear) {

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/infrastructure/adapter/persistence/entity/UserJpaEntity.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/infrastructure/adapter/persistence/entity/UserJpaEntity.java
@@ -53,6 +53,8 @@ public class UserJpaEntity extends TimeBaseEntity {
 
 	private String transferCredit;
 
+	private String exchangeCredit;
+
 	private int totalCredit;
 
 	private double takenCredit;

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/infrastructure/adapter/persistence/mapper/UserMapper.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/infrastructure/adapter/persistence/mapper/UserMapper.java
@@ -1,5 +1,6 @@
 package com.plzgraduate.myongjigraduatebe.user.infrastructure.adapter.persistence.mapper;
 
+import com.plzgraduate.myongjigraduatebe.user.domain.model.ExchangeCredit;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.TransferCredit;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
 import com.plzgraduate.myongjigraduatebe.user.infrastructure.adapter.persistence.entity.UserJpaEntity;
@@ -10,49 +11,51 @@ public class UserMapper {
 
 	public User mapToDomainEntity(UserJpaEntity user) {
 		return User.builder()
-			.id(user.getId())
-			.authId(user.getAuthId())
-			.password(user.getPassword())
-			.name(user.getName())
-			.studentNumber(user.getStudentNumber())
-			.entryYear(user.getEntryYear())
-			.englishLevel(user.getEnglishLevel())
-			.primaryMajor(user.getMajor())
-			.dualMajor(user.getDualMajor())
-			.subMajor(user.getSubMajor())
-			.associatedMajor(user.getAssociatedMajor())
-			.transferCredit(TransferCredit.from(user.getTransferCredit()))
-			.studentCategory(user.getStudentCategory())
-			.totalCredit(user.getTotalCredit())
-			.takenCredit(user.getTakenCredit())
-			.graduated(user.isGraduated())
-			.createdAt(user.getCreatedAt())
-			.updatedAt(user.getUpdatedAt())
-			.build();
+				.id(user.getId())
+				.authId(user.getAuthId())
+				.password(user.getPassword())
+				.name(user.getName())
+				.studentNumber(user.getStudentNumber())
+				.entryYear(user.getEntryYear())
+				.englishLevel(user.getEnglishLevel())
+				.primaryMajor(user.getMajor())
+				.dualMajor(user.getDualMajor())
+				.subMajor(user.getSubMajor())
+				.associatedMajor(user.getAssociatedMajor())
+				.transferCredit(TransferCredit.from(user.getTransferCredit()))
+				.exchangeCredit(ExchangeCredit.from(user.getExchangeCredit()))
+				.studentCategory(user.getStudentCategory())
+				.totalCredit(user.getTotalCredit())
+				.takenCredit(user.getTakenCredit())
+				.graduated(user.isGraduated())
+				.createdAt(user.getCreatedAt())
+				.updatedAt(user.getUpdatedAt())
+				.build();
 	}
 
 	public UserJpaEntity mapToJpaEntity(User user) {
 
 		return UserJpaEntity.builder()
-			.id(user.getId())
-			.authId(user.getAuthId())
-			.password(user.getPassword())
-			.name(user.getName())
-			.englishLevel(user.getEnglishLevel())
-			.studentNumber(user.getStudentNumber())
-			.entryYear(user.getEntryYear())
-			.major(user.getPrimaryMajor())
-			.dualMajor(user.getDualMajor())
-			.subMajor(user.getSubMajor())
-			.associatedMajor(user.getAssociatedMajor())
-			.transferCredit(user.getTransferCredit().toString())
-			.studentCategory(user.getStudentCategory())
-			.totalCredit(user.getTotalCredit())
-			.takenCredit(user.getTakenCredit())
-			.graduated(user.isGraduated())
-			.createdAt(user.getCreatedAt())
-			.updatedAt(user.getUpdatedAt())
-			.build();
+				.id(user.getId())
+				.authId(user.getAuthId())
+				.password(user.getPassword())
+				.name(user.getName())
+				.englishLevel(user.getEnglishLevel())
+				.studentNumber(user.getStudentNumber())
+				.entryYear(user.getEntryYear())
+				.major(user.getPrimaryMajor())
+				.dualMajor(user.getDualMajor())
+				.subMajor(user.getSubMajor())
+				.associatedMajor(user.getAssociatedMajor())
+				.transferCredit(user.getTransferCredit().toString())
+				.exchangeCredit(user.getExchangeCredit().toString())
+				.studentCategory(user.getStudentCategory())
+				.totalCredit(user.getTotalCredit())
+				.takenCredit(user.getTakenCredit())
+				.graduated(user.isGraduated())
+				.createdAt(user.getCreatedAt())
+				.updatedAt(user.getUpdatedAt())
+				.build();
 	}
 
 }

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/fixture/UserFixture.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/fixture/UserFixture.java
@@ -1,136 +1,145 @@
 package com.plzgraduate.myongjigraduatebe.fixture;
 
-import com.plzgraduate.myongjigraduatebe.user.domain.model.EnglishLevel;
-import com.plzgraduate.myongjigraduatebe.user.domain.model.StudentCategory;
-import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.*;
 
 public class UserFixture {
 
 	public static User 영문학과_16학번() {
 		return createUser("mj01", "1234", EnglishLevel.ENG12, "김영문", "60161001", 16, "영어영문학과", null,
-			StudentCategory.NORMAL);
+			StudentCategory.NORMAL, "0/0/0/0", "0/0/0/0/0/0/0/0");
 	}
 
 	public static User 영문학과_18학번() {
 		return createUser("mj01", "1234", EnglishLevel.ENG12, "김영문", "60181001", 18, "영어영문학과", null,
-			StudentCategory.NORMAL);
+			StudentCategory.NORMAL, "0/0/0/0", "0/0/0/0/0/0/0/0");
 	}
 
 	public static User 철학과_20학번() {
 		return createUser("mj51", "1234", EnglishLevel.ENG34, "김철학", "60201011", 20, "철학학과", null,
-			StudentCategory.NORMAL);
+			StudentCategory.NORMAL, "0/0/0/0", "0/0/0/0/0/0/0/0");
 	}
 
 	public static User 행정학과_21학번() {
 		return createUser("mj12", "1234", EnglishLevel.ENG34, "김행정", "60211012", 21, "행정학과", null,
-			StudentCategory.NORMAL);
+			StudentCategory.NORMAL, "0/0/0/0", "0/0/0/0/0/0/0/0");
 	}
 
 	public static User 경영학과_19학번_ENG12() {
 		return createUser("mj21", "1234", EnglishLevel.ENG12, "김경영", "60191021", 19, "경영학과", null,
-			StudentCategory.NORMAL);
+			StudentCategory.NORMAL, "0/0/0/0", "0/0/0/0/0/0/0/0");
 	}
 
 	public static User 경영학과_19학번_ENG34() {
 		return createUser("mj21", "1234", EnglishLevel.ENG34, "김경영", "60191021", 19, "경영학과", null,
-			StudentCategory.NORMAL);
+			StudentCategory.NORMAL, "0/0/0/0", "0/0/0/0/0/0/0/0");
 	}
 
 	public static User 경영학과_19학번_영어_면제() {
 		return createUser("mj21", "1234", EnglishLevel.FREE, "김경영", "60191021", 19, "경영학과", null,
-			StudentCategory.NORMAL);
+			StudentCategory.NORMAL, "0/0/0/0", "0/0/0/0/0/0/0/0");
 	}
 
 	public static User 경영학과_22학번() {
 		return createUser("mj22", "1234", EnglishLevel.ENG34, "김경영", "60221022", 22, "경영학과", null,
-			StudentCategory.NORMAL);
+			StudentCategory.NORMAL, "0/0/0/0", "0/0/0/0/0/0/0/0");
 	}
 
 	public static User 경영학과_23학번() {
 		return createUser("mj22", "1234", EnglishLevel.ENG34, "김경영", "60231022", 23, "경영학과", null,
-			StudentCategory.NORMAL);
+			StudentCategory.NORMAL,"0/0/0/0", "0/0/0/0/0/0/0/0");
 	}
 
 	public static User 경영학과_23학번_국제통상학과_부전공() {
 		return createUser("mj22", "1234", EnglishLevel.ENG34, "김경영", "60231022", 23, "경영학과",
 			"국제통상학과",
-			StudentCategory.SUB_MAJOR);
+			StudentCategory.SUB_MAJOR, "0/0/0/0", "0/0/0/0/0/0/0/0");
 	}
 
 	public static User 국제통상학과_19학번() {
 		return createUser("mj31", "1234", EnglishLevel.ENG34, "김국통", "60192021", 19, "국제통상학과", null,
-			StudentCategory.NORMAL);
+			StudentCategory.NORMAL, "0/0/0/0", "0/0/0/0/0/0/0/0");
 	}
 
 	public static User 데이테크놀로지학과_16학번() {
 		return createUser("mj1001", "1234", EnglishLevel.ENG12, "정데테", "60161666", 16, "데이터테크놀로지전공",
 			null,
-			StudentCategory.NORMAL);
+			StudentCategory.NORMAL,"0/0/0/0", "0/0/0/0/0/0/0/0");
 	}
 
 	public static User 데이테크놀로지학과_16학번_Eng34() {
 		return createUser("mj1001", "1234", EnglishLevel.ENG34, "정데테", "60161666", 16, "데이터테크놀로지전공",
 			null,
-			StudentCategory.NORMAL);
+			StudentCategory.NORMAL, "0/0/0/0", "0/0/0/0/0/0/0/0");
 	}
 
 	public static User 데이테크놀로지학과_18학번_Basic_Eng() {
 		return createUser("mj1001", "1234", EnglishLevel.BASIC, "정데테", "60181666", 18, "데이터테크놀로지전공",
 			null,
-			StudentCategory.NORMAL);
+			StudentCategory.NORMAL,"0/0/0/0", "0/0/0/0/0/0/0/0");
 	}
 
 	public static User 데이테크놀로지학과_18학번() {
 		return createUser("mj1003", "1234", EnglishLevel.ENG12, "정데테", "60181666", 18, "데이터테크놀로지전공",
 			null,
-			StudentCategory.NORMAL);
+			StudentCategory.NORMAL, "0/0/0/0", "0/0/0/0/0/0/0/0");
 	}
 	public static User 경제학과_20학번_편입() {
 		return createUser("mj1003", "1234", EnglishLevel.FREE, "최편입", "60191666", 20, "경제학과",
 				null,
-				StudentCategory.NORMAL);
+				StudentCategory.TRANSFER, "0/0/0/0", "0/0/0/0/0/0/0/0");
 	}
 
 	public static User 응용소프트웨어학과_17학번() {
 		return createUser("mj22", "1234", EnglishLevel.ENG34, "김응용", "60171022", 17, "응용소프트웨어전공",
 			null,
-			StudentCategory.NORMAL);
+			StudentCategory.NORMAL, "0/0/0/0", "0/0/0/0/0/0/0/0");
 	}
 
 	public static User 응용소프트웨어학과_19학번() {
 		return createUser("mj22", "1234", EnglishLevel.ENG34, "김응용", "60191022", 19, "응용소프트웨어전공",
 			null,
-			StudentCategory.NORMAL);
+			StudentCategory.NORMAL, "0/0/0/0", "0/0/0/0/0/0/0/0");
 	}
 
 	public static User 응용소프트웨어학과_19학번_영어_면제() {
 		return createUser("mj22", "1234", EnglishLevel.FREE, "김응용", "60191022", 19, "응용소프트웨어전공",
 			null,
-			StudentCategory.NORMAL);
+			StudentCategory.NORMAL, "0/0/0/0", "0/0/0/0/0/0/0/0");
 	}
 
 	public static User 데이터테크놀로지학과_19학번() {
 		return createUser("mj22", "1234", EnglishLevel.ENG34, "김응용", "60191022", 19, "데이터테크놀로지전공",
 			null,
-			StudentCategory.NORMAL);
+			StudentCategory.NORMAL, "0/0/0/0", "0/0/0/0/0/0/0/0");
 	}
 
 	public static User 디지털콘텐츠디자인학과_19학번() {
 		return createUser("mj22", "1234", EnglishLevel.ENG34, "김응용", "60191022", 19, "디지털콘텐츠디자인학과",
 			null,
-			StudentCategory.NORMAL);
+			StudentCategory.NORMAL, "0/0/0/0", "0/0/0/0/0/0/0/0");
 	}
 
 	public static User 디지털콘텐츠디자인학과_23학번() {
 		return createUser("mj22", "1234", EnglishLevel.ENG34, "김응용", "60231022", 23, "디지털콘텐츠디자인학과",
 			null,
-			StudentCategory.NORMAL);
+			StudentCategory.NORMAL, "0/0/0/0", "0/0/0/0/0/0/0/0");
 	}
-
+	public static User 영문학과_18학번_교환_학문기초3학점() {
+		return createUser("mj01", "1234", EnglishLevel.ENG12, "김영문", "60181001", 18, "영어영문학과", null,
+				StudentCategory.NORMAL, "0/0/0/0", "3/0/0/0/0/0/0/0");
+	}
+	public static User 경제학과_18학번_교환_자율학점3학점() {
+		return createUser("mj01", "1234", EnglishLevel.ENG12, "김경제", "60181001", 18, "경제학과", null,
+				StudentCategory.NORMAL, "0/0/0/0", "0/0/0/0/0/0/0/0");
+	}
+	public static User 경영학과_19학번_ENG34_교환학생_일반학점_3() {
+		return createUser("mj21", "1234", EnglishLevel.ENG34, "김경영", "60191021", 19, "경영학과", null,
+				StudentCategory.NORMAL, "0/0/0/0", "0/3/0/0/0/0/0/0");
+	}
 	public static User createUser(String authId, String password, EnglishLevel englishLevel,
 		String name,
 		String studentNumber,
-		int entryYear, String major, String subMajor, StudentCategory studentCategory) {
+		int entryYear, String major, String subMajor, StudentCategory studentCategory, String transferCredit, String exchangeCredit) {
 		return User.builder()
 			.id(1L)
 			.authId(authId)
@@ -142,6 +151,8 @@ public class UserFixture {
 			.primaryMajor(major)
 			.subMajor(subMajor)
 			.studentCategory(studentCategory)
+			.transferCredit(TransferCredit.from(transferCredit))
+			.exchangeCredit(ExchangeCredit.from(exchangeCredit))
 			.build();
 	}
 }

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/fixture/UserFixture.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/fixture/UserFixture.java
@@ -5,141 +5,144 @@ import com.plzgraduate.myongjigraduatebe.user.domain.model.*;
 public class UserFixture {
 
 	public static User 영문학과_16학번() {
-		return createUser("mj01", "1234", EnglishLevel.ENG12, "김영문", "60161001", 16, "영어영문학과", null,
+		return createUser("mj01", "1234", EnglishLevel.ENG12, "김영문", "60161001", 16, "영어영문학과", null, null,
 			StudentCategory.NORMAL, "0/0/0/0", "0/0/0/0/0/0/0/0");
 	}
 
 	public static User 영문학과_18학번() {
-		return createUser("mj01", "1234", EnglishLevel.ENG12, "김영문", "60181001", 18, "영어영문학과", null,
+		return createUser("mj01", "1234", EnglishLevel.ENG12, "김영문", "60181001", 18, "영어영문학과", null, null,
 			StudentCategory.NORMAL, "0/0/0/0", "0/0/0/0/0/0/0/0");
 	}
 
 	public static User 철학과_20학번() {
-		return createUser("mj51", "1234", EnglishLevel.ENG34, "김철학", "60201011", 20, "철학학과", null,
+		return createUser("mj51", "1234", EnglishLevel.ENG34, "김철학", "60201011", 20, "철학학과", null, null,
 			StudentCategory.NORMAL, "0/0/0/0", "0/0/0/0/0/0/0/0");
 	}
 
 	public static User 행정학과_21학번() {
-		return createUser("mj12", "1234", EnglishLevel.ENG34, "김행정", "60211012", 21, "행정학과", null,
+		return createUser("mj12", "1234", EnglishLevel.ENG34, "김행정", "60211012", 21, "행정학과", null, null,
 			StudentCategory.NORMAL, "0/0/0/0", "0/0/0/0/0/0/0/0");
 	}
 
 	public static User 경영학과_19학번_ENG12() {
-		return createUser("mj21", "1234", EnglishLevel.ENG12, "김경영", "60191021", 19, "경영학과", null,
+		return createUser("mj21", "1234", EnglishLevel.ENG12, "김경영", "60191021", 19, "경영학과", null, null,
 			StudentCategory.NORMAL, "0/0/0/0", "0/0/0/0/0/0/0/0");
 	}
 
 	public static User 경영학과_19학번_ENG34() {
-		return createUser("mj21", "1234", EnglishLevel.ENG34, "김경영", "60191021", 19, "경영학과", null,
+		return createUser("mj21", "1234", EnglishLevel.ENG34, "김경영", "60191021", 19, "경영학과", null, null,
 			StudentCategory.NORMAL, "0/0/0/0", "0/0/0/0/0/0/0/0");
 	}
 
 	public static User 경영학과_19학번_영어_면제() {
-		return createUser("mj21", "1234", EnglishLevel.FREE, "김경영", "60191021", 19, "경영학과", null,
+		return createUser("mj21", "1234", EnglishLevel.FREE, "김경영", "60191021", 19, "경영학과", null, null,
 			StudentCategory.NORMAL, "0/0/0/0", "0/0/0/0/0/0/0/0");
 	}
 
 	public static User 경영학과_22학번() {
-		return createUser("mj22", "1234", EnglishLevel.ENG34, "김경영", "60221022", 22, "경영학과", null,
+		return createUser("mj22", "1234", EnglishLevel.ENG34, "김경영", "60221022", 22, "경영학과", null, null,
 			StudentCategory.NORMAL, "0/0/0/0", "0/0/0/0/0/0/0/0");
 	}
 
 	public static User 경영학과_23학번() {
-		return createUser("mj22", "1234", EnglishLevel.ENG34, "김경영", "60231022", 23, "경영학과", null,
+		return createUser("mj22", "1234", EnglishLevel.ENG34, "김경영", "60231022", 23, "경영학과", null, null,
 			StudentCategory.NORMAL,"0/0/0/0", "0/0/0/0/0/0/0/0");
 	}
 
 	public static User 경영학과_23학번_국제통상학과_부전공() {
-		return createUser("mj22", "1234", EnglishLevel.ENG34, "김경영", "60231022", 23, "경영학과",
+		return createUser("mj22", "1234", EnglishLevel.ENG34, "김경영", "60231022", 23, "경영학과", null,
 			"국제통상학과",
 			StudentCategory.SUB_MAJOR, "0/0/0/0", "0/0/0/0/0/0/0/0");
 	}
 
 	public static User 국제통상학과_19학번() {
-		return createUser("mj31", "1234", EnglishLevel.ENG34, "김국통", "60192021", 19, "국제통상학과", null,
+		return createUser("mj31", "1234", EnglishLevel.ENG34, "김국통", "60192021", 19, "국제통상학과", null, null,
 			StudentCategory.NORMAL, "0/0/0/0", "0/0/0/0/0/0/0/0");
 	}
 
 	public static User 데이테크놀로지학과_16학번() {
-		return createUser("mj1001", "1234", EnglishLevel.ENG12, "정데테", "60161666", 16, "데이터테크놀로지전공",
+		return createUser("mj1001", "1234", EnglishLevel.ENG12, "정데테", "60161666", 16, "데이터테크놀로지전공", null,
 			null,
 			StudentCategory.NORMAL,"0/0/0/0", "0/0/0/0/0/0/0/0");
 	}
 
 	public static User 데이테크놀로지학과_16학번_Eng34() {
-		return createUser("mj1001", "1234", EnglishLevel.ENG34, "정데테", "60161666", 16, "데이터테크놀로지전공",
+		return createUser("mj1001", "1234", EnglishLevel.ENG34, "정데테", "60161666", 16, "데이터테크놀로지전공", null,
 			null,
 			StudentCategory.NORMAL, "0/0/0/0", "0/0/0/0/0/0/0/0");
 	}
 
 	public static User 데이테크놀로지학과_18학번_Basic_Eng() {
-		return createUser("mj1001", "1234", EnglishLevel.BASIC, "정데테", "60181666", 18, "데이터테크놀로지전공",
+		return createUser("mj1001", "1234", EnglishLevel.BASIC, "정데테", "60181666", 18, "데이터테크놀로지전공", null,
 			null,
 			StudentCategory.NORMAL,"0/0/0/0", "0/0/0/0/0/0/0/0");
 	}
 
 	public static User 데이테크놀로지학과_18학번() {
-		return createUser("mj1003", "1234", EnglishLevel.ENG12, "정데테", "60181666", 18, "데이터테크놀로지전공",
+		return createUser("mj1003", "1234", EnglishLevel.ENG12, "정데테", "60181666", 18, "데이터테크놀로지전공", null,
 			null,
 			StudentCategory.NORMAL, "0/0/0/0", "0/0/0/0/0/0/0/0");
 	}
 	public static User 경제학과_20학번_편입() {
-		return createUser("mj1003", "1234", EnglishLevel.FREE, "최편입", "60191666", 20, "경제학과",
+		return createUser("mj1003", "1234", EnglishLevel.FREE, "최편입", "60191666", 20, "경제학과", null,
 				null,
 				StudentCategory.TRANSFER, "0/0/0/0", "0/0/0/0/0/0/0/0");
 	}
 
 	public static User 응용소프트웨어학과_17학번() {
-		return createUser("mj22", "1234", EnglishLevel.ENG34, "김응용", "60171022", 17, "응용소프트웨어전공",
+		return createUser("mj22", "1234", EnglishLevel.ENG34, "김응용", "60171022", 17, "응용소프트웨어전공", null,
 			null,
 			StudentCategory.NORMAL, "0/0/0/0", "0/0/0/0/0/0/0/0");
 	}
 
 	public static User 응용소프트웨어학과_19학번() {
-		return createUser("mj22", "1234", EnglishLevel.ENG34, "김응용", "60191022", 19, "응용소프트웨어전공",
+		return createUser("mj22", "1234", EnglishLevel.ENG34, "김응용", "60191022", 19, "응용소프트웨어전공", null,
 			null,
 			StudentCategory.NORMAL, "0/0/0/0", "0/0/0/0/0/0/0/0");
 	}
 
 	public static User 응용소프트웨어학과_19학번_영어_면제() {
-		return createUser("mj22", "1234", EnglishLevel.FREE, "김응용", "60191022", 19, "응용소프트웨어전공",
-			null,
-			StudentCategory.NORMAL, "0/0/0/0", "0/0/0/0/0/0/0/0");
+		return createUser("mj22", "1234", EnglishLevel.FREE, "김응용", "60191022", 19, "응용소프트웨어전공", null,null,
+			 StudentCategory.NORMAL, "0/0/0/0", "0/0/0/0/0/0/0/0");
 	}
 
 	public static User 데이터테크놀로지학과_19학번() {
-		return createUser("mj22", "1234", EnglishLevel.ENG34, "김응용", "60191022", 19, "데이터테크놀로지전공",
+		return createUser("mj22", "1234", EnglishLevel.ENG34, "김응용", "60191022", 19, "데이터테크놀로지전공", null,
 			null,
 			StudentCategory.NORMAL, "0/0/0/0", "0/0/0/0/0/0/0/0");
 	}
 
 	public static User 디지털콘텐츠디자인학과_19학번() {
-		return createUser("mj22", "1234", EnglishLevel.ENG34, "김응용", "60191022", 19, "디지털콘텐츠디자인학과",
+		return createUser("mj22", "1234", EnglishLevel.ENG34, "김응용", "60191022", 19, "디지털콘텐츠디자인학과", null,
 			null,
 			StudentCategory.NORMAL, "0/0/0/0", "0/0/0/0/0/0/0/0");
 	}
 
 	public static User 디지털콘텐츠디자인학과_23학번() {
-		return createUser("mj22", "1234", EnglishLevel.ENG34, "김응용", "60231022", 23, "디지털콘텐츠디자인학과",
+		return createUser("mj22", "1234", EnglishLevel.ENG34, "김응용", "60231022", 23, "디지털콘텐츠디자인학과", null,
 			null,
 			StudentCategory.NORMAL, "0/0/0/0", "0/0/0/0/0/0/0/0");
 	}
 	public static User 영문학과_18학번_교환_학문기초3학점() {
-		return createUser("mj01", "1234", EnglishLevel.ENG12, "김영문", "60181001", 18, "영어영문학과", null,
+		return createUser("mj01", "1234", EnglishLevel.ENG12, "김영문", "60181001", 18, "영어영문학과", null, null,
 				StudentCategory.NORMAL, "0/0/0/0", "3/0/0/0/0/0/0/0");
 	}
 	public static User 경제학과_18학번_교환_자율학점3학점() {
-		return createUser("mj01", "1234", EnglishLevel.ENG12, "김경제", "60181001", 18, "경제학과", null,
+		return createUser("mj01", "1234", EnglishLevel.ENG12, "김경제", "60181001", 18, "경제학과", null, null,
 				StudentCategory.NORMAL, "0/0/0/0", "0/0/0/0/0/0/0/0");
 	}
 	public static User 경영학과_19학번_ENG34_교환학생_일반학점_3() {
-		return createUser("mj21", "1234", EnglishLevel.ENG34, "김경영", "60191021", 19, "경영학과", null,
+		return createUser("mj21", "1234", EnglishLevel.ENG34, "김경영", "60191021", 19, "경영학과", null, null,
 				StudentCategory.NORMAL, "0/0/0/0", "0/3/0/0/0/0/0/0");
+	}
+	public static User 응용_경영_복전_19학번_교환학생() {
+		return createUser("mj21", "1234", EnglishLevel.ENG34, "김융경", "60191021", 19, "응용소프트웨어전공", null, "경영학과",
+				StudentCategory.DUAL_MAJOR, "0/0/0/0", "0/0/0/0/15/0/0/0");
 	}
 	public static User createUser(String authId, String password, EnglishLevel englishLevel,
 		String name,
 		String studentNumber,
-		int entryYear, String major, String subMajor, StudentCategory studentCategory, String transferCredit, String exchangeCredit) {
+		int entryYear, String major, String dualMajor, String subMajor, StudentCategory studentCategory, String transferCredit, String exchangeCredit) {
 		return User.builder()
 			.id(1L)
 			.authId(authId)
@@ -149,6 +152,7 @@ public class UserFixture {
 			.studentNumber(studentNumber)
 			.entryYear(entryYear)
 			.primaryMajor(major)
+			.dualMajor(dualMajor)
 			.subMajor(subMajor)
 			.studentCategory(studentCategory)
 			.transferCredit(TransferCredit.from(transferCredit))

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateBasicAcademicalCultureGraduationServiceTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateBasicAcademicalCultureGraduationServiceTest.java
@@ -24,6 +24,7 @@ import com.plzgraduate.myongjigraduatebe.lecture.domain.model.BasicAcademicalCul
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.Lecture;
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLecture;
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.ExchangeCredit;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
 import java.util.HashSet;
 import java.util.List;
@@ -44,6 +45,7 @@ class CalculateBasicAcademicalCultureGraduationServiceTest {
 	private CalculateBasicAcademicalCultureGraduationService calculateBasicAcademicalCultureGraduationService;
 
 	private User user;
+	private User user2;
 
 	@BeforeEach
 	void setUp() {
@@ -60,6 +62,15 @@ class CalculateBasicAcademicalCultureGraduationServiceTest {
 			.studentCategory(DUAL_MAJOR)
 			.entryYear(19)
 			.build();
+
+		 user2 = User.builder()
+				.id(1L)
+				.primaryMajor("응용소프트웨어전공")
+				.dualMajor("경영학과")
+				.studentCategory(DUAL_MAJOR)
+				 .exchangeCredit(ExchangeCredit.from("0/0/0/6/0/0/0/0"))
+				.entryYear(19)
+				.build();
 	}
 
 	@DisplayName("BASIC_ACADEMICAL_CULTURE 관련 카테고리 일때만 BasicAcademicalCultureGraduationService를 호출한다.")
@@ -138,5 +149,43 @@ class CalculateBasicAcademicalCultureGraduationServiceTest {
 		assertThat(detailCoreCultureGraduationResult)
 			.extracting("graduationCategory", "isCompleted", "totalCredit", "takenCredit")
 			.contains(DUAL_BASIC_ACADEMICAL_CULTURE, false, 18, 3.0);
+	}
+	@DisplayName("교환학생 인정 학점을 포함한 복수학문 기초교양 상세 졸업결과를 계산한다.")
+	@Test
+	void shouldCalculateSingleDetailGraduationWithExchangeCredit() {
+		//given
+
+		HashSet<BasicAcademicalCultureLecture> graduationBasicAcademicalCultures = new HashSet<>(
+				Set.of(BasicAcademicalCultureLecture.of(Lecture.from("KMA02128"), BUSINESS.getName())));
+
+		HashSet<TakenLecture> takenLectures = new HashSet<>(
+				Set.of(
+						TakenLecture.builder()
+								.lecture(Lecture.builder()
+										.id("KMA02128")
+										.credit(3)
+										.build())
+								.build()));
+		TakenLectureInventory takenLectureInventory = TakenLectureInventory.from(takenLectures);
+
+		GraduationRequirement graduationRequirement = GraduationRequirement.builder()
+				.dualBasicAcademicalCultureCredit(18)
+				.build();
+
+		given(findBasicAcademicalCulturePort.findBasicAcademicalCulture(anyString())).willReturn(
+				graduationBasicAcademicalCultures);
+
+		//when
+		DetailGraduationResult dualBasicAcademicalCultureDetailGraduationResult = calculateBasicAcademicalCultureGraduationService.calculateSingleDetailGraduation(
+				user2, DUAL_BASIC_ACADEMICAL_CULTURE, takenLectureInventory, graduationRequirement);
+
+		int additionalCredits = user2.getExchangeCredit().getDualBasicAcademicalCulture();
+		dualBasicAcademicalCultureDetailGraduationResult.addCredit(additionalCredits);
+
+		//then
+		assertThat(dualBasicAcademicalCultureDetailGraduationResult)
+				.extracting("graduationCategory", "isCompleted", "totalCredit", "takenCredit")
+				.contains(DUAL_BASIC_ACADEMICAL_CULTURE, false, 18, 9.0); // 교환학점 6 + 수강학점 3 = 9
+
 	}
 }

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateMajorGraduationServiceTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateMajorGraduationServiceTest.java
@@ -27,6 +27,7 @@ import com.plzgraduate.myongjigraduatebe.lecture.domain.model.Lecture;
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.MajorLecture;
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLecture;
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.ExchangeCredit;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.StudentCategory;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.TransferCredit;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
@@ -389,5 +390,114 @@ class CalculateMajorGraduationServiceTest {
 		assertThat(detailPrimaryElectiveMajorGraduationResult)
 				.extracting("graduationCategory", "isCompleted", "totalCredit", "takenCredit")
 				.contains(PRIMARY_ELECTIVE_MAJOR, 18.0); // 15 (편입 학점) + 3 (수강 학점)
+	}
+	@DisplayName("교환학생 전공선택 학점 졸업 결과를 계산한다.")
+	@Test
+	void calculateSingleDetailGraduationForExchangePrimaryElective() {
+		// given
+		User user = User.builder()
+				.id(1L)
+				.primaryMajor("응용소프트웨어전공")
+				.entryYear(19)
+				.studentCategory(StudentCategory.NORMAL)
+				.exchangeCredit(ExchangeCredit.from("0/0/3/0/0/0/0/0")) // 3 전공 선택 학점
+				.build();
+
+		HashSet<MajorLecture> graduationMajorLectures = new HashSet<>(
+				Set.of(
+						MajorLecture.of(Lecture.builder()
+								.id("HEC01211")
+								.credit(3)
+								.build(), "응용소프트웨어전공", 1, 16, 23),
+						MajorLecture.of(Lecture.builder()
+								.id("HEC01305")
+								.credit(3)
+								.build(), "응용소프트웨어전공", 0, 16, 23)
+				)
+		);
+		given(findMajorPort.findMajor(user.getPrimaryMajor())).willReturn(graduationMajorLectures);
+
+		HashSet<TakenLecture> takenLectures = new HashSet<>(
+				Set.of(
+						TakenLecture.builder()
+								.lecture(Lecture.builder()
+										.id("HEC01305") // 전공 선택
+										.credit(3)
+										.build())
+								.build()
+				)
+		);
+		TakenLectureInventory takenLectureInventory = TakenLectureInventory.from(takenLectures);
+
+		GraduationRequirement graduationRequirement = GraduationRequirement.builder()
+				.primaryMajorCredit(70) // 전공 학점 총합
+				.build();
+
+		// when
+		DetailGraduationResult detailPrimaryElectiveMajorGraduationResult = calculateMajorGraduationService.calculateSingleDetailGraduation(
+				user, PRIMARY_ELECTIVE_MAJOR, takenLectureInventory, graduationRequirement);
+
+		// then
+		assertThat(detailPrimaryElectiveMajorGraduationResult)
+				.extracting("graduationCategory", "isCompleted", "totalCredit", "takenCredit")
+				.contains(PRIMARY_ELECTIVE_MAJOR, false, 67, 6.0); // 3 (교환 학점) + 3 (교환학생 인정 학점)
+	}
+	@DisplayName("교환 학생 유저의 복수전공선택 졸업결과를 계산한다.")
+	@Test
+	void calculateDualMajorWithExchangeCredits() {
+		//given
+		User user = User.builder()
+				.id(1L)
+				.studentCategory(StudentCategory.DUAL_MAJOR)
+				.dualMajor("응용소프트웨어전공")
+				.entryYear(19)
+				.exchangeCredit(ExchangeCredit.from("0/0/0/0/15/0/0/0")) // 교환 학점 15 설정
+				.build();
+
+		HashSet<MajorLecture> graduationMajorLectures = new HashSet<>(
+				Set.of(
+						MajorLecture.of(Lecture.builder()
+								.id("HEC01211")
+								.credit(3)
+								.build(), "응용소프트웨어전공", 1, 16, 23),
+						MajorLecture.of(Lecture.builder()
+								.id("HEC01304")
+								.credit(3)
+								.build(), "응용소프트웨어전공", 0, 16, 23)));
+
+		given(findMajorPort.findMajor(user.getDualMajor())).willReturn(graduationMajorLectures);
+
+		HashSet<TakenLecture> takenLectures = new HashSet<>(
+				Set.of(
+						TakenLecture.builder()
+								.lecture(Lecture.builder()
+										.id("HEC01211") // 전공 필수
+										.credit(3)
+										.build())
+								.build(),
+						TakenLecture.builder()
+								.lecture(Lecture.builder()
+										.id("HEC01304") // 전공 선택
+										.credit(3)
+										.build())
+								.build()));
+
+		TakenLectureInventory takenLectureInventory = TakenLectureInventory.from(takenLectures);
+
+		GraduationRequirement graduationRequirement = GraduationRequirement.builder()
+				.dualMajorCredit(70)
+				.build();
+
+		//when
+		DetailGraduationResult detailDualElectiveMajorGraduationResult = calculateMajorGraduationService.calculateSingleDetailGraduation(
+				user, DUAL_ELECTIVE_MAJOR, takenLectureInventory, graduationRequirement);
+
+		int additionalCredits = user.getExchangeCredit().getDualMajor();
+		detailDualElectiveMajorGraduationResult.addCredit(additionalCredits);
+
+		//then
+		assertThat(detailDualElectiveMajorGraduationResult)
+				.extracting("graduationCategory", "isCompleted", "totalCredit", "takenCredit")
+				.contains(DUAL_ELECTIVE_MAJOR, false, 67, 18.0); // 교환학생 인점 학점 15 + 전공 선택 수강 학점 3 = 18
 	}
 }

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/FreeElectiveGraduationResultTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/domain/model/FreeElectiveGraduationResultTest.java
@@ -14,195 +14,227 @@ import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureI
 import com.plzgraduate.myongjigraduatebe.user.domain.model.StudentCategory;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.TransferCredit;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
+
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class FreeElectiveGraduationResultTest {
 
-	Map<String, Lecture> mockLectureMap = LectureFixture.getMockLectureMap();
+    Map<String, Lecture> mockLectureMap = LectureFixture.getMockLectureMap();
 
-	@DisplayName("처리되지 않은 전공 수강과목과 다른 카테고리(공통, 핵심, 학문기초교양, 전공, 일반교양)의 남은 자유선택 학점으로 자유선택 졸업 결과를 생성한다.")
+    @DisplayName("처리되지 않은 전공 수강과목과 다른 카테고리(공통, 핵심, 학문기초교양, 전공, 일반교양)의 남은 자유선택 학점으로 자유선택 졸업 결과를 생성한다.")
+    @Test
+    void createFreeElectiveGraduationResult() {
+        //given
+        User user = UserFixture.경영학과_19학번_ENG34();
+        Set<TakenLecture> takenLectures = new HashSet<>((Set.of(
+                TakenLecture.of(user, mockLectureMap.get("HBX01104"), 2019, Semester.FIRST), //회계원리
+                TakenLecture.of(user, mockLectureMap.get("HBX01113"), 2019, Semester.FIRST), //인적자원관리
+                TakenLecture.of(user, mockLectureMap.get("HBX01106"), 2020, Semester.FIRST), //마케팅원론
+                TakenLecture.of(user, mockLectureMap.get("HBX01105"), 2020, Semester.SECOND), //재무관리원론
+                TakenLecture.of(user, mockLectureMap.get("HBX01143"), 2021, Semester.FIRST) //운영관리
+        )));
+        TakenLectureInventory takenLectureInventory = TakenLectureInventory.from(takenLectures);
+
+        DetailGraduationResult detailGraduationResult = DetailGraduationResult.builder()
+                .graduationCategory(FREE_ELECTIVE)
+                .detailCategory(List.of(
+                        DetailCategoryResult.builder()
+                                .detailCategoryName(CHRISTIAN_A.getName())
+                                .freeElectiveLeftCredit(3)
+                                .build(),
+                        DetailCategoryResult.builder()
+                                .detailCategoryName(SCIENCE_TECHNOLOGY.getName())
+                                .freeElectiveLeftCredit(3)
+                                .build()
+                ))
+                .build();
+
+        int remainCreditByTakenLectures = takenLectureInventory.getTakenLectures()
+                .stream()
+                .mapToInt(takenLecture -> takenLecture.getLecture()
+                        .getCredit())
+                .sum();
+        int freeElectiveLeftCredit = detailGraduationResult.getFreeElectiveLeftCredit();
+        int leftNormalCultureCredit = 5;
+
+        //when
+        FreeElectiveGraduationResult freeElectiveGraduationResult = FreeElectiveGraduationResult.create(
+                7,
+                takenLectureInventory, List.of(detailGraduationResult),
+                leftNormalCultureCredit, user);
+
+        //then
+        assertThat(freeElectiveGraduationResult)
+                .extracting("categoryName", "takenCredit")
+                .contains(FREE_ELECTIVE.getName(),
+                        remainCreditByTakenLectures + freeElectiveLeftCredit + leftNormalCultureCredit);
+    }
+
+    @DisplayName("봉사학점을 한 번 들었을 때 자유선택 졸업 결과를 생성한다.")
+    @Test
+    void createFreeElectiveGraduationResult_withOneVolunteerCredit() {
+        //given
+        User user = UserFixture.경영학과_19학번_ENG34();
+        Set<TakenLecture> takenLectures = new HashSet<>((Set.of(
+                TakenLecture.of(user, mockLectureMap.get("KMA02198"), 2021, Semester.FIRST) // 봉사학점
+        )));
+        TakenLectureInventory takenLectureInventory = TakenLectureInventory.from(takenLectures);
+
+        int totalFreeElectiveCredit = 7;
+        int leftNormalCultureCredit = 0;
+
+        //when
+        FreeElectiveGraduationResult freeElectiveGraduationResult = FreeElectiveGraduationResult.create(
+                totalFreeElectiveCredit,
+                takenLectureInventory,
+                List.of(),
+                leftNormalCultureCredit,
+                user);
+
+        //then
+        assertThat(freeElectiveGraduationResult)
+                .extracting("categoryName", "takenCredit")
+                .contains(FREE_ELECTIVE.getName(), 1); // 봉사학점 1학점 반영
+    }
+
+    @DisplayName("봉사학점을 두 번 들었을 때 자유선택 졸업 결과를 생성한다.")
+    @Test
+    void createFreeElectiveGraduationResult_withTwoVolunteerCredits() {
+        //given
+        User user = UserFixture.경영학과_19학번_ENG34();
+        Set<TakenLecture> takenLectures = new HashSet<>((Set.of(
+                TakenLecture.of(user, mockLectureMap.get("KMA02198"), 2021, Semester.FIRST), // 봉사학점 1
+                TakenLecture.of(user, mockLectureMap.get("KMA02198"), 2022, Semester.SECOND) // 봉사학점 2
+        )));
+        TakenLectureInventory takenLectureInventory = TakenLectureInventory.from(takenLectures);
+
+        int totalFreeElectiveCredit = 7;
+        int leftNormalCultureCredit = 0;
+
+        //when
+        FreeElectiveGraduationResult freeElectiveGraduationResult = FreeElectiveGraduationResult.create(
+                totalFreeElectiveCredit,
+                takenLectureInventory,
+                List.of(),
+                leftNormalCultureCredit,
+                user);
+
+        //then
+        assertThat(freeElectiveGraduationResult)
+                .extracting("categoryName", "takenCredit")
+                .contains(FREE_ELECTIVE.getName(), 2); // 봉사학점 2학점 반영
+    }
+
+    @DisplayName("편입생의 자유선택 졸업 결과를 생성한다.")
+    @Test
+    void createFreeElectiveGraduationResult_forTransferStudent() {
+        // given
+        User user = UserFixture.경제학과_20학번_편입();
+        user.setStudentCategory(StudentCategory.TRANSFER);
+        user.setTransferCredit(new TransferCredit(51, 0, 3, 0)); // 편입 학점 설정
+
+        // Taken lectures (총 9학점)
+        Set<TakenLecture> takenLectures = new HashSet<>(Set.of(
+                TakenLecture.of(user, mockLectureMap.get("HBX01104"), 2019, Semester.FIRST),
+                TakenLecture.of(user, mockLectureMap.get("HBX01113"), 2019, Semester.FIRST),
+                TakenLecture.of(user, mockLectureMap.get("HBX01106"), 2020, Semester.FIRST)
+        ));
+        TakenLectureInventory takenLectureInventory = TakenLectureInventory.from(takenLectures);
+
+        // 교양 초과분 (남은 4학점이 자유선택으로 넘어가야 함)
+        DetailGraduationResult combinedCultureGraduationResult = DetailGraduationResult.builder()
+                .graduationCategory(GraduationCategory.NORMAL_CULTURE)
+                .detailCategory(List.of(
+                        DetailCategoryResult.builder()
+                                .detailCategoryName("일반교양")
+                                .freeElectiveLeftCredit(4) // 초과된 통합 교양 학점
+                                .build()
+                ))
+                .build();
+
+        int leftNormalCultureCredit = 1;
+
+        // when
+        FreeElectiveGraduationResult freeElectiveGraduationResult = FreeElectiveGraduationResult.create(
+                14,
+                takenLectureInventory,
+                List.of(combinedCultureGraduationResult),
+                leftNormalCultureCredit,
+                user
+        );
+
+        // then
+        assertThat(freeElectiveGraduationResult)
+                .extracting("categoryName", "takenCredit")
+                .contains(FREE_ELECTIVE.getName(),
+                        17); // 편입 학점 포함 계산
+    }
+
+    @DisplayName("편입생 봉사학점을 포함한 자유선택 졸업 결과를 생성한다.")
+    @Test
+    void createFreeElectiveGraduationResult_withVolunteerCredits_forTransferStudent() {
+        // given
+        User user = UserFixture.경제학과_20학번_편입();
+        user.setStudentCategory(StudentCategory.TRANSFER);
+        user.setTransferCredit(new TransferCredit(0, 0, 3, 0)); // 편입 학점 설정
+
+        Set<TakenLecture> takenLectures = new HashSet<>(Set.of(
+                TakenLecture.of(user, mockLectureMap.get("KMA02198"), 2021, Semester.FIRST), // 봉사학점 1
+                TakenLecture.of(user, mockLectureMap.get("KMA02198"), 2022, Semester.SECOND) // 봉사학점 2
+        ));
+        TakenLectureInventory takenLectureInventory = TakenLectureInventory.from(takenLectures);
+
+        int totalFreeElectiveCredit = 14;
+        int leftNormalCultureCredit = 0;
+
+        // when
+        FreeElectiveGraduationResult freeElectiveGraduationResult = FreeElectiveGraduationResult.create(
+                totalFreeElectiveCredit,
+                takenLectureInventory,
+                List.of(),
+                leftNormalCultureCredit,
+                user
+        );
+
+        // then
+        assertThat(freeElectiveGraduationResult)
+                .extracting("categoryName", "takenCredit")
+                .contains(FREE_ELECTIVE.getName(), 5); // 봉사학점 2 + 편입 학점 3 + 기타 계산
+    }
+
+	@DisplayName("교환학생 학점이 반영된 자유선택 졸업 결과를 생성한다.")
 	@Test
-	void createFreeElectiveGraduationResult() {
+	void createFreeElectiveGraduationResult_withExchangeCredits() {
 		//given
-		User user = UserFixture.경영학과_19학번_ENG34();
-		Set<TakenLecture> takenLectures = new HashSet<>((Set.of(
-			TakenLecture.of(user, mockLectureMap.get("HBX01104"), 2019, Semester.FIRST), //회계원리
-			TakenLecture.of(user, mockLectureMap.get("HBX01113"), 2019, Semester.FIRST), //인적자원관리
-			TakenLecture.of(user, mockLectureMap.get("HBX01106"), 2020, Semester.FIRST), //마케팅원론
-			TakenLecture.of(user, mockLectureMap.get("HBX01105"), 2020, Semester.SECOND), //재무관리원론
-			TakenLecture.of(user, mockLectureMap.get("HBX01143"), 2021, Semester.FIRST) //운영관리
-		)));
-		TakenLectureInventory takenLectureInventory = TakenLectureInventory.from(takenLectures);
-
-		DetailGraduationResult detailGraduationResult = DetailGraduationResult.builder()
-			.graduationCategory(FREE_ELECTIVE)
-			.detailCategory(List.of(
-				DetailCategoryResult.builder()
-					.detailCategoryName(CHRISTIAN_A.getName())
-					.freeElectiveLeftCredit(3)
-					.build(),
-				DetailCategoryResult.builder()
-					.detailCategoryName(SCIENCE_TECHNOLOGY.getName())
-					.freeElectiveLeftCredit(3)
-					.build()
-			))
-			.build();
-
-		int remainCreditByTakenLectures = takenLectureInventory.getTakenLectures()
-			.stream()
-			.mapToInt(takenLecture -> takenLecture.getLecture()
-				.getCredit())
-			.sum();
-		int freeElectiveLeftCredit = detailGraduationResult.getFreeElectiveLeftCredit();
-		int leftNormalCultureCredit = 5;
-
-		//when
-		FreeElectiveGraduationResult freeElectiveGraduationResult = FreeElectiveGraduationResult.create(
-			7,
-			takenLectureInventory, List.of(detailGraduationResult),
-			leftNormalCultureCredit,user);
-
-		//then
-		assertThat(freeElectiveGraduationResult)
-			.extracting("categoryName", "takenCredit")
-			.contains(FREE_ELECTIVE.getName(),
-				remainCreditByTakenLectures + freeElectiveLeftCredit + leftNormalCultureCredit);
-	}
-
-	@DisplayName("봉사학점을 한 번 들었을 때 자유선택 졸업 결과를 생성한다.")
-	@Test
-	void createFreeElectiveGraduationResult_withOneVolunteerCredit() {
-		//given
-		User user = UserFixture.경영학과_19학번_ENG34();
-		Set<TakenLecture> takenLectures = new HashSet<>((Set.of(
-				TakenLecture.of(user, mockLectureMap.get("KMA02198"), 2021, Semester.FIRST) // 봉사학점
-		)));
-		TakenLectureInventory takenLectureInventory = TakenLectureInventory.from(takenLectures);
-
-		int totalFreeElectiveCredit = 7;
-		int leftNormalCultureCredit = 0;
-
-		//when
-		FreeElectiveGraduationResult freeElectiveGraduationResult = FreeElectiveGraduationResult.create(
-				totalFreeElectiveCredit,
-				takenLectureInventory,
-				List.of(),
-				leftNormalCultureCredit,
-				user);
-
-		//then
-		assertThat(freeElectiveGraduationResult)
-				.extracting("categoryName", "takenCredit")
-				.contains(FREE_ELECTIVE.getName(), 1); // 봉사학점 1학점 반영
-	}
-
-	@DisplayName("봉사학점을 두 번 들었을 때 자유선택 졸업 결과를 생성한다.")
-	@Test
-	void createFreeElectiveGraduationResult_withTwoVolunteerCredits() {
-		//given
-		User user = UserFixture.경영학과_19학번_ENG34();
-		Set<TakenLecture> takenLectures = new HashSet<>((Set.of(
-				TakenLecture.of(user, mockLectureMap.get("KMA02198"), 2021, Semester.FIRST), // 봉사학점 1
-				TakenLecture.of(user, mockLectureMap.get("KMA02198"), 2022, Semester.SECOND) // 봉사학점 2
-		)));
-		TakenLectureInventory takenLectureInventory = TakenLectureInventory.from(takenLectures);
-
-		int totalFreeElectiveCredit = 7;
-		int leftNormalCultureCredit = 0;
-
-		//when
-		FreeElectiveGraduationResult freeElectiveGraduationResult = FreeElectiveGraduationResult.create(
-				totalFreeElectiveCredit,
-				takenLectureInventory,
-				List.of(),
-				leftNormalCultureCredit,
-				user);
-
-		//then
-		assertThat(freeElectiveGraduationResult)
-				.extracting("categoryName", "takenCredit")
-				.contains(FREE_ELECTIVE.getName(), 2); // 봉사학점 2학점 반영
-	}
-	@DisplayName("편입생의 자유선택 졸업 결과를 생성한다.")
-	@Test
-	void createFreeElectiveGraduationResult_forTransferStudent() {
-		// given
-		User user = UserFixture.경제학과_20학번_편입();
-		user.setStudentCategory(StudentCategory.TRANSFER);
-		user.setTransferCredit(new TransferCredit(51, 0, 3,0)); // 편입 학점 설정
-
-		// Taken lectures (총 9학점)
+		User userWithExchangeCredits = UserFixture.경제학과_18학번_교환_자율학점3학점(); // 교환학생 자유학점 3점 추가
 		Set<TakenLecture> takenLectures = new HashSet<>(Set.of(
-				TakenLecture.of(user, mockLectureMap.get("HBX01104"), 2019, Semester.FIRST),
-				TakenLecture.of(user, mockLectureMap.get("HBX01113"), 2019, Semester.FIRST),
-				TakenLecture.of(user, mockLectureMap.get("HBX01106"), 2020, Semester.FIRST)
+				TakenLecture.of(userWithExchangeCredits, mockLectureMap.get("HBX01104"), 2019, Semester.FIRST), // 회계원리
+				TakenLecture.of(userWithExchangeCredits, mockLectureMap.get("HBX01113"), 2019, Semester.FIRST)  // 인적자원관리
 		));
 		TakenLectureInventory takenLectureInventory = TakenLectureInventory.from(takenLectures);
 
-		// 교양 초과분 (남은 4학점이 자유선택으로 넘어가야 함)
-		DetailGraduationResult combinedCultureGraduationResult = DetailGraduationResult.builder()
-				.graduationCategory(GraduationCategory.NORMAL_CULTURE)
-				.detailCategory(List.of(
-						DetailCategoryResult.builder()
-								.detailCategoryName("일반교양")
-								.freeElectiveLeftCredit(4) // 초과된 통합 교양 학점
-								.build()
-				))
-				.build();
+		int totalFreeElectiveCredit = 7;
+		int leftNormalCultureCredit = 2;
 
-		int leftNormalCultureCredit = 1;
-
-		// when
-		FreeElectiveGraduationResult freeElectiveGraduationResult = FreeElectiveGraduationResult.create(
-				14,
-				takenLectureInventory,
-				List.of(combinedCultureGraduationResult),
-				leftNormalCultureCredit,
-				user
-		);
-
-		// then
-		assertThat(freeElectiveGraduationResult)
-				.extracting("categoryName", "takenCredit")
-				.contains(FREE_ELECTIVE.getName(),
-						17); // 편입 학점 포함 계산
-	}
-
-	@DisplayName("편입생 봉사학점을 포함한 자유선택 졸업 결과를 생성한다.")
-	@Test
-	void createFreeElectiveGraduationResult_withVolunteerCredits_forTransferStudent() {
-		// given
-		User user = UserFixture.경제학과_20학번_편입();
-		user.setStudentCategory(StudentCategory.TRANSFER);
-		user.setTransferCredit(new TransferCredit(0, 0, 3,0)); // 편입 학점 설정
-
-		Set<TakenLecture> takenLectures = new HashSet<>(Set.of(
-				TakenLecture.of(user, mockLectureMap.get("KMA02198"), 2021, Semester.FIRST), // 봉사학점 1
-				TakenLecture.of(user, mockLectureMap.get("KMA02198"), 2022, Semester.SECOND) // 봉사학점 2
-		));
-		TakenLectureInventory takenLectureInventory = TakenLectureInventory.from(takenLectures);
-
-		int totalFreeElectiveCredit = 14;
-		int leftNormalCultureCredit = 0;
-
-		// when
+		//when
 		FreeElectiveGraduationResult freeElectiveGraduationResult = FreeElectiveGraduationResult.create(
 				totalFreeElectiveCredit,
 				takenLectureInventory,
 				List.of(),
 				leftNormalCultureCredit,
-				user
+				userWithExchangeCredits
 		);
-
-		// then
+		freeElectiveGraduationResult.checkCompleted();
+		//then
 		assertThat(freeElectiveGraduationResult)
-				.extracting("categoryName", "takenCredit")
-				.contains(FREE_ELECTIVE.getName(), 5); // 봉사학점 2 + 편입 학점 3 + 기타 계산
+				.extracting("categoryName", "takenCredit", "isCompleted")
+				.contains(FREE_ELECTIVE.getName(), 8, true); // 교환학생 학점 포함 8학점으로 졸업 요건 충족
 	}
 }
 

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/basicacademicalculture/DefaultBasicAcademicalGraduationManagerTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/basicacademicalculture/DefaultBasicAcademicalGraduationManagerTest.java
@@ -28,6 +28,7 @@ class DefaultBasicAcademicalGraduationManagerTest {
 	class 인문대_학문기초교양 {
 
 		User user = UserFixture.영문학과_18학번();
+		User user2 = UserFixture.영문학과_18학번_교환_학문기초3학점();
 		Map<String, Lecture> mockLectureMap = LectureFixture.getMockLectureMap();
 		Set<BasicAcademicalCultureLecture> basicAcademicalLectures = BasicAcademicalLectureFixture.인문대_학문기초교양();
 
@@ -97,6 +98,74 @@ class DefaultBasicAcademicalGraduationManagerTest {
 
 			assertThat(detailCategoryResult.getTakenLectures()).hasSize(3);
 			assertThat(detailCategoryResult.getHaveToLectures()).hasSize(10);
+		}
+
+
+		@DisplayName("교환학생 학점이 추가된 경우 학문기초교양을 통과한다.")
+		@Test
+		void 영문학과_교환학생_학점_추가() {
+			//given
+			Set<TakenLecture> takenLectures = new HashSet<>(Set.of(
+					TakenLecture.of(user2, mockLectureMap.get("KMB02127"), 2019, Semester.FIRST),
+					TakenLecture.of(user2, mockLectureMap.get("KMB02119"), 2019, Semester.FIRST),
+					TakenLecture.of(user2, mockLectureMap.get("KMB02120"), 2020, Semester.FIRST)
+			));
+			TakenLectureInventory takenLectureInventory = TakenLectureInventory.from(takenLectures);
+			BasicAcademicalGraduationManager manager = new DefaultBasicAcademicalGraduationManager();
+
+			//when
+			DetailGraduationResult detailGraduationResult = manager.createDetailGraduationResult(
+					user2,
+					takenLectureInventory, basicAcademicalLectures, 12);
+
+			DetailCategoryResult detailCategoryResult = detailGraduationResult.getDetailCategory()
+					.get(0);
+
+			//then
+			assertThat(detailGraduationResult)
+					.extracting("isCompleted", "totalCredit", "takenCredit")
+					.contains(true, 12, 12.0); // 교환학생 학점 포함하여 12학점 달성
+
+			assertThat(detailCategoryResult)
+					.extracting("detailCategoryName", "isCompleted", "totalCredits", "takenCredits")
+					.contains("학문기초교양", true, 12, 12);
+
+			assertThat(detailCategoryResult.getTakenLectures()).hasSize(3);
+			assertThat(detailCategoryResult.getHaveToLectures()).hasSize(10);
+
+		}
+
+		@DisplayName("교환학생 학점이 추가되었지만 부족한 학점으로 인해 통과하지 못한다.")
+		@Test
+		void 영문학과_교환학생_학점_부족() {
+			//given
+
+			Set<TakenLecture> takenLectures = new HashSet<>(Set.of(
+					TakenLecture.of(user2, mockLectureMap.get("KMB02127"), 2019, Semester.FIRST),
+					TakenLecture.of(user2, mockLectureMap.get("KMB02119"), 2019, Semester.FIRST)
+			));
+			TakenLectureInventory takenLectureInventory = TakenLectureInventory.from(takenLectures);
+			BasicAcademicalGraduationManager manager = new DefaultBasicAcademicalGraduationManager();
+
+			//when
+			DetailGraduationResult detailGraduationResult = manager.createDetailGraduationResult(
+					user2,
+					takenLectureInventory, basicAcademicalLectures, 12);
+
+			DetailCategoryResult detailCategoryResult = detailGraduationResult.getDetailCategory()
+					.get(0);
+
+			//then
+			assertThat(detailGraduationResult)
+					.extracting("isCompleted", "totalCredit", "takenCredit")
+					.contains(false, 12, 9.0); // 교환학생 학점 포함하여도 9학점으로 부족
+
+			assertThat(detailCategoryResult)
+					.extracting("detailCategoryName", "isCompleted", "totalCredits", "takenCredits")
+					.contains("학문기초교양", false, 12, 9);
+
+			assertThat(detailCategoryResult.getTakenLectures()).hasSize(2); // 실제 들은 과목 2개
+			assertThat(detailCategoryResult.getHaveToLectures()).hasSize(11); // 부족한 과목
 		}
 	}
 }

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/user/application/service/update/UpdateStudentInformationServiceTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/user/application/service/update/UpdateStudentInformationServiceTest.java
@@ -5,6 +5,7 @@ import static org.testng.AssertJUnit.assertEquals;
 
 import com.plzgraduate.myongjigraduatebe.user.application.port.UpdateUserPort;
 import com.plzgraduate.myongjigraduatebe.user.application.usecase.update.UpdateStudentInformationCommand;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.ExchangeCredit;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.StudentCategory;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.TransferCredit;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
@@ -71,5 +72,32 @@ class UpdateStudentInformationServiceTest {
 
 		// Assert TransferCredit is updated
 		assertEquals(newTransferCredit, user.getTransferCredit());
+	}
+
+	@DisplayName("User의 ExchangeCredit 정보를 수정한다.")
+	@Test
+	void updateUserExchangeCredit() {
+		// given
+		User user = User.builder()
+				.exchangeCredit(ExchangeCredit.empty())
+				.build();
+
+		ExchangeCredit exchangeCredit = new ExchangeCredit(3,3,3,3,3,3,3,3);
+
+		UpdateStudentInformationCommand command = UpdateStudentInformationCommand.builder()
+				.user(user)
+				.name("정지환")
+				.major("응용소프트웨어학과")
+				.exchangeCredit(exchangeCredit)
+				.build();
+
+		// when
+		updateStudentInformationService.updateUser(command);
+
+		// then
+		then(updateUserPort).should()
+				.updateUser(user);
+
+		assertEquals(exchangeCredit, user.getExchangeCredit());
 	}
 }

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/user/application/usecase/update/UpdateStudentInformationCommandTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/user/application/usecase/update/UpdateStudentInformationCommandTest.java
@@ -1,0 +1,82 @@
+package com.plzgraduate.myongjigraduatebe.user.application.usecase.update;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationResult;
+import com.plzgraduate.myongjigraduatebe.parsing.domain.ParsingInformation;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.ExchangeCredit;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.StudentCategory;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.TransferCredit;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class UpdateStudentInformationCommandTest {
+
+    @Test
+    @DisplayName("ParsingInformation을 기반으로 UpdateStudentInformationCommand 생성 테스트")
+    void createFromParsingInformation() {
+        // given
+        User user = User.builder()
+                .id(1L)
+                .name("홍길동")
+                .build();
+
+        ParsingInformation parsingInformation = ParsingInformation.builder()
+                .studentName("홍길동")
+                .major("응용소프트웨어전공")
+                .dualMajor("경영학과")
+                .subMajor("통계학과")
+                .transferCredit(TransferCredit.from("0/0/0/0"))
+                .exchangeCredit(ExchangeCredit.from("0/0/0/0/0/0/0/0"))
+                .studentCategory(StudentCategory.NORMAL)
+                .build();
+
+        // when
+        UpdateStudentInformationCommand command = UpdateStudentInformationCommand.of(user, parsingInformation);
+
+        // then
+        assertThat(command).isNotNull();
+        assertThat(command.getName()).isEqualTo("홍길동");
+        assertThat(command.getMajor()).isEqualTo("응용소프트웨어전공");
+        assertThat(command.getDualMajor()).isEqualTo("경영학과");
+        assertThat(command.getSubMajor()).isEqualTo("통계학과");
+        assertThat(command.getTransferCredit()).isEqualTo(TransferCredit.from("0/0/0/0"));
+        assertThat(command.getExchangeCredit()).isEqualTo(ExchangeCredit.from("0/0/0/0/0/0/0/0"));
+        assertThat(command.getStudentCategory()).isEqualTo(StudentCategory.NORMAL);
+    }
+
+    @Test
+    @DisplayName("GraduationResult를 기반으로 UpdateStudentInformationCommand 업데이트 테스트")
+    void updateFromGraduationResult() {
+        // given
+        User user = User.builder()
+                .id(1L)
+                .name("홍길동")
+                .primaryMajor("응용소프트웨어전공")
+                .dualMajor("경영학과")
+                .subMajor("통계학과")
+                .studentCategory(StudentCategory.DUAL_MAJOR)
+                .build();
+
+        GraduationResult graduationResult = GraduationResult.builder()
+                .totalCredit(130)
+                .takenCredit(120)
+                .graduated(true)
+                .build();
+
+        // when
+        UpdateStudentInformationCommand command = UpdateStudentInformationCommand.update(user, graduationResult);
+
+        // then
+        assertThat(command).isNotNull();
+        assertThat(command.getName()).isEqualTo("홍길동");
+        assertThat(command.getMajor()).isEqualTo("응용소프트웨어전공");
+        assertThat(command.getDualMajor()).isEqualTo("경영학과");
+        assertThat(command.getSubMajor()).isEqualTo("통계학과");
+        assertThat(command.getStudentCategory()).isEqualTo(StudentCategory.DUAL_MAJOR);
+        assertThat(command.getTotalCredit()).isEqualTo(130);
+        assertThat(command.getTakenCredit()).isEqualTo(120);
+        assertThat(command.isGraduate()).isTrue();
+    }
+}

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/user/domain/model/UserTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/user/domain/model/UserTest.java
@@ -51,7 +51,7 @@ class UserTest {
 	@Test
 	void updateStudentInformation() {
 		//given //when
-		user.updateStudentInformation("테스터2", "경영학과", null, null,  null, StudentCategory.CHANGE_MAJOR, null,134,
+		user.updateStudentInformation("테스터2", "경영학과", null, null,  null, StudentCategory.CHANGE_MAJOR, null, null, 134,
 			120.5, true);
 		//then
 		assertThat(user)

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/user/infrastructure/adapter/persistence/UserPersistenceAdapterTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/user/infrastructure/adapter/persistence/UserPersistenceAdapterTest.java
@@ -3,6 +3,7 @@ package com.plzgraduate.myongjigraduatebe.user.infrastructure.adapter.persistenc
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.plzgraduate.myongjigraduatebe.support.PersistenceTestSupport;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.ExchangeCredit;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.StudentCategory;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.TransferCredit;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
@@ -118,6 +119,7 @@ class UserPersistenceAdapterTest extends PersistenceTestSupport {
 				.password("1q2w3e4r!")
 				.studentNumber("60181666")
 				.transferCredit(new TransferCredit(0, 0, 0, 0))
+				.exchangeCredit(new ExchangeCredit(0, 0, 0, 0, 0, 0, 0, 0))
 				.studentCategory(StudentCategory.NORMAL)
 				.build();
 	}
@@ -130,6 +132,7 @@ class UserPersistenceAdapterTest extends PersistenceTestSupport {
 				.password("1q2w3e4r!")
 				.studentNumber(studentNumber)
 				.transferCredit("0/0/0/0")
+				.exchangeCredit("0/0/0/0/0/0/0/0")
 				.studentCategory(StudentCategory.NORMAL)
 				.build();
 	}

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/user/infrastructure/adapter/persistence/mapper/UserMapperTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/user/infrastructure/adapter/persistence/mapper/UserMapperTest.java
@@ -3,10 +3,7 @@ package com.plzgraduate.myongjigraduatebe.user.infrastructure.adapter.persistenc
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.plzgraduate.myongjigraduatebe.support.PersistenceTestSupport;
-import com.plzgraduate.myongjigraduatebe.user.domain.model.EnglishLevel;
-import com.plzgraduate.myongjigraduatebe.user.domain.model.StudentCategory;
-import com.plzgraduate.myongjigraduatebe.user.domain.model.TransferCredit;
-import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.*;
 import com.plzgraduate.myongjigraduatebe.user.infrastructure.adapter.persistence.entity.UserJpaEntity;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -37,6 +34,9 @@ class UserMapperTest extends PersistenceTestSupport {
 		assertThat(user.getTransferCredit())
 				.extracting("normalCulture", "majorLecture", "freeElective", "christianLecture")
 				.containsExactly(0, 0, 0, 0);
+		assertThat(user.getExchangeCredit())
+				.extracting("basicAcademicalCulture", "normalCulture", "major", "dualBasicAcademicalCulture", "dualMajor", "fusionMajor", "subMajor", "freeElective")
+				.containsExactly(0, 0, 0, 0, 0, 0, 0, 0);
 
 	}
 
@@ -58,6 +58,8 @@ class UserMapperTest extends PersistenceTestSupport {
 				"60211111", 21, "경영", null, StudentCategory.NORMAL, 100, 40.0, false);
 		assertThat(userJpaEntity.getTransferCredit())
 				.isEqualTo("0/0/0/0");
+		assertThat(userJpaEntity.getExchangeCredit())
+				.isEqualTo("0/0/0/0/0/0/0/0");
 	}
 
 	private User createUser() {
@@ -73,6 +75,7 @@ class UserMapperTest extends PersistenceTestSupport {
 			.dualMajor(null)
 			.subMajor(null)
 			.transferCredit(TransferCredit.from("0/0/0/0"))
+			.exchangeCredit(ExchangeCredit.from("0/0/0/0/0/0/0/0"))
 			.totalCredit(100)
 			.takenCredit(40)
 			.graduated(false)
@@ -94,6 +97,7 @@ class UserMapperTest extends PersistenceTestSupport {
 				.subMajor(null)
 				.associatedMajor(null)
 				.transferCredit("0/0/0/0") // 기본값 설정
+				.exchangeCredit("0/0/0/0/0/0/0/0") //기본값 설정
 				.studentCategory(StudentCategory.NORMAL)
 				.totalCredit(100)
 				.takenCredit(40.0)


### PR DESCRIPTION
## Issue

## ✅ 작업 내용
교환 학생 인정 학점을 추가
*  교환학생 인정학점 - 학문기초교양 0, 일반교양 0, 전공 0, 복수전공학문기초교양 0, 복수전공 0, 연계전공 0, 부전공 0, 자유선택 0
*  exchange_credit = "0/0/0/0/0/0/0/0"

미 지원하는 연계전공 학점을 제외한 교환 학생 인정 학점들을 taken_credit에 더하여 계산

## 🤔 고민 했던 부분
따로 StudentCategory를 만들려고 하였으나 그렇게 되면 기존 로직을 활용할 수 없고 상황에 맞는 여러 카테고리가 필요하기에 따로 만들지않고 어떤 유형의 학생이든 상관 없이 exchange_credit 에 인정학점이 존재하면 해당 학점을 더해주는 식으로 구현 하였습니다.

## 🔊 도움이 필요한 부분!!
