### PR TITLE
[DEV-57] Redis 캐싱 적용 및 반복 조회 응답 속도 최적화

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,10 +51,29 @@ jobs:
           host: ${{ secrets.WAS_HOST }}
           username: ${{ secrets.WAS_USERNAME }}
           key: ${{ secrets.WAS_KEY }}
-          script : |
+          script: |
             cd ~/mju-graduate-server
-            docker stop $(docker ps -a -q) 
+
+            echo " Redis 컨테이너 실행 (기존에 없을 경우만)"
+            docker ps -a --format '{{.Names}}' | grep -q '^mg-redis$' || \
+            docker run -d --name mg-redis -p 6379:6379 redis:latest
+            echo "기존 앱 컨테이너 중지 및 삭제"
+            docker stop mju-graduate-server || true
+            docker rm mju-graduate-server || true
+
+            echo "최신 앱 이미지 pull"
             docker pull ${{ secrets.DOCKERHUB_USERNAME }}/mju-graduate-server:v2
-            docker rm -f $(docker ps -a -q) 
-            docker run -d --name mju-graduate-server -p 8080:8080 ${{ secrets.DOCKERHUB_USERNAME }}/mju-graduate-server:v2
+
+            echo "앱 컨테이너 실행"
+            docker run -d --name mju-graduate-server \
+              -p 8080:8080 \
+              -e SPRING_PROFILES_ACTIVE=prod \
+              -e JWT_SECRET=${{ secrets.JWT_SECRET }} \
+              -e DATASOURCE_URL=${{ secrets.DATASOURCE_URL }} \
+              -e DATASOURCE_USERNAME=${{ secrets.DATASOURCE_USERNAME }} \
+              -e DATASOURCE_PASSWORD=${{ secrets.DATASOURCE_PASSWORD }} \
+              -e REDIS_HOST=localhost \
+              -e REDIS_PORT=6379 \
+              ${{ secrets.DOCKERHUB_USERNAME }}/mju-graduate-server:v2
+
             docker image prune -f

--- a/build.gradle
+++ b/build.gradle
@@ -41,11 +41,12 @@ dependencies {
 //    implementation 'org.flywaydb:flyway-core:6.4.2'
     implementation 'org.springdoc:springdoc-openapi-ui:1.6.15'
     implementation 'io.sentry:sentry-logback:1.7.30'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     runtimeOnly 'mysql:mysql-connector-java'
-    compileOnly 'org.projectlombok:lombok'
+    compileOnly 'org.projectlombok:lombok:1.18.30'
 
-    annotationProcessor 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok:1.18.30'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
     testImplementation 'org.testng:testng:7.9.0'
@@ -55,16 +56,16 @@ dependencies {
     testImplementation 'org.testcontainers:testcontainers:1.19.0'
     testImplementation 'org.testcontainers:mysql:1.19.0'
     testImplementation 'org.testcontainers:junit-jupiter:1.13.0'
-    testCompileOnly 'org.projectlombok:lombok'
-    testAnnotationProcessor 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok:1.18.30'
+    testAnnotationProcessor 'org.projectlombok:lombok:1.18.30'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.testcontainers:testcontainers:1.19.0'
     testImplementation 'org.testcontainers:mysql:1.19.0'
     testImplementation 'org.testcontainers:junit-jupiter:1.19.0'
-    testCompileOnly 'org.projectlombok:lombok'
-    testAnnotationProcessor 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok:1.18.30'
+    testAnnotationProcessor 'org.projectlombok:lombok:1.18.30'
 }
 tasks.named('test') {
     useJUnitPlatform()

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/MyongjiGraduateBeApplication.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/MyongjiGraduateBeApplication.java
@@ -2,7 +2,9 @@ package com.plzgraduate.myongjigraduatebe;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
+@EnableCaching
 @SpringBootApplication
 public class MyongjiGraduateBeApplication {
 

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/core/config/RedisCacheConfig.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/core/config/RedisCacheConfig.java
@@ -7,6 +7,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
 
 import java.time.Duration;
 import java.util.HashMap;
@@ -18,14 +20,20 @@ public class RedisCacheConfig {
 
     @Bean
     public RedisCacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
-        // 기본 TTL 설정: 30분
-        RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
-                .entryTtl(Duration.ofMinutes(30));
+        // JDK 직렬화 사용
+        RedisSerializationContext.SerializationPair<Object> jdkSerializer =
+                RedisSerializationContext.SerializationPair.fromSerializer(new JdkSerializationRedisSerializer());
 
-        // 캐시별 TTL 개별 설정
+        // 기본 TTL: 30분
+        RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(30))
+                .serializeValuesWith(jdkSerializer);
+
+        // 캐시별 TTL 설정
         Map<String, RedisCacheConfiguration> cacheConfigurations = new HashMap<>();
         cacheConfigurations.put("takenLectures", RedisCacheConfiguration.defaultCacheConfig()
-                .entryTtl(Duration.ofMinutes(10)));
+                .entryTtl(Duration.ofMinutes(10))
+                .serializeValuesWith(jdkSerializer));
 
         return RedisCacheManager.builder(redisConnectionFactory)
                 .cacheDefaults(defaultConfig)
@@ -33,7 +41,6 @@ public class RedisCacheConfig {
                 .build();
     }
 
-    // 캐시 오류 발생 시 무시하도록 설정 (선택사항)
     @Bean
     public SimpleCacheErrorHandler errorHandler() {
         return new SimpleCacheErrorHandler();

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/core/config/RedisCacheConfig.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/core/config/RedisCacheConfig.java
@@ -1,5 +1,6 @@
 package com.plzgraduate.myongjigraduatebe.core.config;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.interceptor.SimpleCacheErrorHandler;
 import org.springframework.context.annotation.Bean;
@@ -16,6 +17,7 @@ import java.util.Map;
 
 @Configuration
 @EnableCaching
+@ConditionalOnBean(RedisConnectionFactory.class)
 public class RedisCacheConfig {
 
     @Bean

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/core/config/RedisCacheConfig.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/core/config/RedisCacheConfig.java
@@ -1,0 +1,41 @@
+package com.plzgraduate.myongjigraduatebe.core.config;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.interceptor.SimpleCacheErrorHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@EnableCaching
+public class RedisCacheConfig {
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+        // 기본 TTL 설정: 30분
+        RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(30));
+
+        // 캐시별 TTL 개별 설정
+        Map<String, RedisCacheConfiguration> cacheConfigurations = new HashMap<>();
+        cacheConfigurations.put("takenLectures", RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(10)));
+
+        return RedisCacheManager.builder(redisConnectionFactory)
+                .cacheDefaults(defaultConfig)
+                .withInitialCacheConfigurations(cacheConfigurations)
+                .build();
+    }
+
+    // 캐시 오류 발생 시 무시하도록 설정 (선택사항)
+    @Bean
+    public SimpleCacheErrorHandler errorHandler() {
+        return new SimpleCacheErrorHandler();
+    }
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/lecture/domain/model/Lecture.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/lecture/domain/model/Lecture.java
@@ -1,11 +1,13 @@
 package com.plzgraduate.myongjigraduatebe.lecture.domain.model;
 
+import java.io.Serializable;
 import java.util.Objects;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-public class Lecture {
+public class Lecture implements Serializable {
+	private static final long serialVersionUID = 1L;
 
 	private static final String CULTURE_CODE_START_PREFIX = "KM";
 

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/api/ParsingTextController.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/api/ParsingTextController.java
@@ -5,6 +5,7 @@ import com.plzgraduate.myongjigraduatebe.core.meta.WebAdapter;
 import com.plzgraduate.myongjigraduatebe.parsing.api.dto.request.ParsingTextRequest;
 import com.plzgraduate.myongjigraduatebe.parsing.application.usecase.ParsingTextHistoryUseCase;
 import com.plzgraduate.myongjigraduatebe.parsing.application.usecase.ParsingTextUseCase;
+import org.springframework.cache.annotation.CacheEvict;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -20,6 +21,7 @@ public class ParsingTextController implements ParsingTextApiPresentation {
 	private final ParsingTextHistoryUseCase parsingTextHistoryUseCase;
 
 	@PostMapping
+	@CacheEvict(value = "takenLectures", key = "#userId")
 	public void enrollParsingText(
 		@LoginUser Long userId,
 		@Valid @RequestBody ParsingTextRequest parsingTextRequest

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/api/ParsingTextController.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/api/ParsingTextController.java
@@ -5,12 +5,11 @@ import com.plzgraduate.myongjigraduatebe.core.meta.WebAdapter;
 import com.plzgraduate.myongjigraduatebe.parsing.api.dto.request.ParsingTextRequest;
 import com.plzgraduate.myongjigraduatebe.parsing.application.usecase.ParsingTextHistoryUseCase;
 import com.plzgraduate.myongjigraduatebe.parsing.application.usecase.ParsingTextUseCase;
-import org.springframework.cache.annotation.CacheEvict;
-import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import javax.validation.Valid;
 
 @WebAdapter
 @RequestMapping("/api/v1/parsing-text")
@@ -19,13 +18,14 @@ public class ParsingTextController implements ParsingTextApiPresentation {
 
 	private final ParsingTextUseCase parsingTextUseCase;
 	private final ParsingTextHistoryUseCase parsingTextHistoryUseCase;
+	private final TakenLectureCacheEvict takenLectureCacheEvict;
 
 	@PostMapping
-	@CacheEvict(value = "takenLectures", key = "#userId")
 	public void enrollParsingText(
 		@LoginUser Long userId,
 		@Valid @RequestBody ParsingTextRequest parsingTextRequest
 	) {
+		takenLectureCacheEvict.evictTakenLecturesCache(userId);
 		try {
 			parsingTextUseCase.enrollParsingText(userId, parsingTextRequest.getParsingText());
 			parsingTextHistoryUseCase.generateSucceedParsingTextHistory(

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/api/TakenLectureCacheEvict.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/api/TakenLectureCacheEvict.java
@@ -1,0 +1,17 @@
+package com.plzgraduate.myongjigraduatebe.parsing.api;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TakenLectureCacheEvict {
+    @Value("${spring.profiles.active:}")
+    private String profile;
+
+    @CacheEvict(value = "takenLectures", key = "#userId")
+    public void evictTakenLecturesCache(Long userId) {
+        if ("test".equals(profile)) return;
+        // 실제 환경에서는 캐시 삭제
+    }
+} 

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/takenlecture/api/UpdateTakenLectureController.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/takenlecture/api/UpdateTakenLectureController.java
@@ -7,6 +7,7 @@ import com.plzgraduate.myongjigraduatebe.takenlecture.application.usecase.delete
 import com.plzgraduate.myongjigraduatebe.takenlecture.application.usecase.save.GenerateCustomizedTakenLectureUseCase;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -22,6 +23,7 @@ public class UpdateTakenLectureController implements UpdateTakenLectureApiPresen
 	private final DeleteTakenLectureUseCase deleteTakenLectureUseCase;
 
 	@PostMapping()
+	@CacheEvict(value = "takenLectures", key = "#userId")
 	public void generateCustomizedTakenLecture(@LoginUser Long userId,
 		@Valid @RequestBody GenerateCustomizedTakenLectureRequest generateCustomizedTakenLectureRequest) {
 		generateCustomizedTakenLectureUseCase.generateCustomizedTakenLecture(userId,
@@ -29,6 +31,7 @@ public class UpdateTakenLectureController implements UpdateTakenLectureApiPresen
 	}
 
 	@DeleteMapping("{takenLectureId}")
+	@CacheEvict(value = "takenLectures", key = "#userId")
 	public void deleteCustomizedTakenLecture(@LoginUser Long userId,
 		@Valid @PathVariable Long takenLectureId) {
 		deleteTakenLectureUseCase.deleteTakenLecture(userId, takenLectureId);

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/takenlecture/api/UpdateTakenLectureController.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/takenlecture/api/UpdateTakenLectureController.java
@@ -2,12 +2,13 @@ package com.plzgraduate.myongjigraduatebe.takenlecture.api;
 
 import com.plzgraduate.myongjigraduatebe.core.meta.LoginUser;
 import com.plzgraduate.myongjigraduatebe.core.meta.WebAdapter;
+
+import com.plzgraduate.myongjigraduatebe.parsing.api.TakenLectureCacheEvict;
 import com.plzgraduate.myongjigraduatebe.takenlecture.api.dto.request.GenerateCustomizedTakenLectureRequest;
 import com.plzgraduate.myongjigraduatebe.takenlecture.application.usecase.delete.DeleteTakenLectureUseCase;
 import com.plzgraduate.myongjigraduatebe.takenlecture.application.usecase.save.GenerateCustomizedTakenLectureUseCase;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -21,19 +22,20 @@ public class UpdateTakenLectureController implements UpdateTakenLectureApiPresen
 
 	private final GenerateCustomizedTakenLectureUseCase generateCustomizedTakenLectureUseCase;
 	private final DeleteTakenLectureUseCase deleteTakenLectureUseCase;
+	private final TakenLectureCacheEvict takenLectureCacheEvict;
 
 	@PostMapping()
-	@CacheEvict(value = "takenLectures", key = "#userId")
 	public void generateCustomizedTakenLecture(@LoginUser Long userId,
 		@Valid @RequestBody GenerateCustomizedTakenLectureRequest generateCustomizedTakenLectureRequest) {
 		generateCustomizedTakenLectureUseCase.generateCustomizedTakenLecture(userId,
 			generateCustomizedTakenLectureRequest.getLectureId());
+		takenLectureCacheEvict.evictTakenLecturesCache(userId);
 	}
 
 	@DeleteMapping("{takenLectureId}")
-	@CacheEvict(value = "takenLectures", key = "#userId")
 	public void deleteCustomizedTakenLecture(@LoginUser Long userId,
 		@Valid @PathVariable Long takenLectureId) {
 		deleteTakenLectureUseCase.deleteTakenLecture(userId, takenLectureId);
+		takenLectureCacheEvict.evictTakenLecturesCache(userId);
 	}
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/takenlecture/application/service/find/FindTakenLectureService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/takenlecture/application/service/find/FindTakenLectureService.java
@@ -11,6 +11,7 @@ import java.util.HashSet;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.cache.annotation.Cacheable;
 
 @UseCase
 @Transactional(readOnly = true)
@@ -22,6 +23,7 @@ class FindTakenLectureService implements FindTakenLectureUseCase {
 	private final FindTakenLecturePort findTakenLecturePort;
 
 	@Override
+	@Cacheable(value = "takenLectures", key = "#userId")
 	public TakenLectureInventory findTakenLectures(Long userId) {
 		User user = findUserUseCase.findUserById(userId);
 		List<TakenLecture> takenLectures = findTakenLecturePort.findTakenLecturesByUser(user);

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/takenlecture/domain/model/TakenLecture.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/takenlecture/domain/model/TakenLecture.java
@@ -2,13 +2,16 @@ package com.plzgraduate.myongjigraduatebe.takenlecture.domain.model;
 
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.Lecture;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
+
+import java.io.Serializable;
 import java.time.Instant;
 import java.util.Objects;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-public class TakenLecture {
+public class TakenLecture implements Serializable {
+	private static final long serialVersionUID = 1L;
 
 	private final Long id;
 	private final User user;

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/takenlecture/domain/model/TakenLectureInventory.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/takenlecture/domain/model/TakenLectureInventory.java
@@ -1,13 +1,16 @@
 package com.plzgraduate.myongjigraduatebe.takenlecture.domain.model;
 
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.Lecture;
+
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.Builder;
 
-public class TakenLectureInventory {
+public class TakenLectureInventory implements  Serializable {
+	private static final long serialVersionUID = 1L;
 
 	private final Set<TakenLecture> takenLecture;
 

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/domain/model/ExchangeCredit.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/domain/model/ExchangeCredit.java
@@ -1,5 +1,6 @@
 package com.plzgraduate.myongjigraduatebe.user.domain.model;
 
+import java.io.Serializable;
 import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -8,7 +9,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class ExchangeCredit {
+public class ExchangeCredit implements Serializable {
+    private static final long serialVersionUID = 1L;
 
     private int basicAcademicalCulture;  // 학문기초교양
     private int normalCulture;          // 일반교양

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/domain/model/TransferCredit.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/domain/model/TransferCredit.java
@@ -1,5 +1,6 @@
 package com.plzgraduate.myongjigraduatebe.user.domain.model;
 
+import java.io.Serializable;
 import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -8,7 +9,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class TransferCredit {
+public class TransferCredit implements Serializable {
+    private static final long serialVersionUID = 1L;
 
     private int normalCulture;
     private int majorLecture;

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/domain/model/User.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/domain/model/User.java
@@ -5,6 +5,8 @@ import static com.plzgraduate.myongjigraduatebe.graduation.domain.model.MajorTyp
 
 import com.google.common.annotations.VisibleForTesting;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.MajorType;
+
+import java.io.Serializable;
 import java.time.Instant;
 import java.util.Objects;
 import lombok.Builder;
@@ -12,7 +14,8 @@ import lombok.Getter;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Getter
-public class User {
+public class User implements Serializable {
+	private static final long serialVersionUID = 1L;
 
 	private final Long id;
 	private final String authId;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,10 @@ spring:
         format_sql: true
     open-in-view: false
 
+  redis:
+    host: localhost
+    port: 6380
+
 logging:
   level:
     p6spy: info
@@ -70,6 +74,10 @@ spring:
     hibernate:
       ddl-auto: none
 
+  redis:
+    host: localhost
+    port: 6379
+
 jwt:
   issuer: "plzgraduate"
   secret-key: ${JWT_SECRET}
@@ -91,6 +99,10 @@ spring:
   jpa:
     hibernate:
       ddl-auto: none
+
+  redis:
+    host: localhost
+    port: 6379
 
 jwt:
   issuer: "plzgraduate"

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/auth/api/signin/SignInControllerTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/auth/api/signin/SignInControllerTest.java
@@ -9,12 +9,17 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.plzgraduate.myongjigraduatebe.auth.api.signin.dto.request.SignInRequest;
 import com.plzgraduate.myongjigraduatebe.core.exception.UnAuthorizedException;
+import com.plzgraduate.myongjigraduatebe.parsing.api.TakenLectureCacheEvict;
 import com.plzgraduate.myongjigraduatebe.support.WebAdaptorTestSupport;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 
 class SignInControllerTest extends WebAdaptorTestSupport {
+
+	@MockBean
+	private TakenLectureCacheEvict takenLectureCacheEvict;
 
 	@DisplayName("로그인을 진행한다.")
 	@Test

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/auth/api/token/TokenControllerTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/auth/api/token/TokenControllerTest.java
@@ -11,12 +11,17 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.plzgraduate.myongjigraduatebe.auth.api.token.dto.request.TokenRequest;
 import com.plzgraduate.myongjigraduatebe.auth.api.token.dto.response.AccessTokenResponse;
+import com.plzgraduate.myongjigraduatebe.parsing.api.TakenLectureCacheEvict;
 import com.plzgraduate.myongjigraduatebe.support.WebAdaptorTestSupport;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 
 class TokenControllerTest extends WebAdaptorTestSupport {
+
+	@MockBean
+	private TakenLectureCacheEvict takenLectureCacheEvict;
 
 	@DisplayName("AccessToken 재발급한다.")
 	@Test

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/completedcredit/api/FindCompletedCreditsControllerTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/completedcredit/api/FindCompletedCreditsControllerTest.java
@@ -8,13 +8,18 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.plzgraduate.myongjigraduatebe.completedcredit.domain.model.CompletedCredit;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationCategory;
+import com.plzgraduate.myongjigraduatebe.parsing.api.TakenLectureCacheEvict;
 import com.plzgraduate.myongjigraduatebe.support.WebAdaptorTestSupport;
 import com.plzgraduate.myongjigraduatebe.support.WithMockAuthenticationUser;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 class FindCompletedCreditsControllerTest extends WebAdaptorTestSupport {
+
+	@MockBean
+	private TakenLectureCacheEvict takenLectureCacheEvict;
 
 	@WithMockAuthenticationUser
 	@DisplayName("유저의 이수 학점을 조회한다.")

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/api/FindDetailGraduationsControllerTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/api/FindDetailGraduationsControllerTest.java
@@ -14,13 +14,18 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailCategoryResult;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.DetailGraduationResult;
+import com.plzgraduate.myongjigraduatebe.parsing.api.TakenLectureCacheEvict;
 import com.plzgraduate.myongjigraduatebe.support.WebAdaptorTestSupport;
 import com.plzgraduate.myongjigraduatebe.support.WithMockAuthenticationUser;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 class FindDetailGraduationsControllerTest extends WebAdaptorTestSupport {
+
+	@MockBean
+	private TakenLectureCacheEvict takenLectureCacheEvict;
 
 	@WithMockAuthenticationUser
 	@DisplayName("공통교양 졸업 상세 결과를 조회한다.")

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/lecture/api/SearchLectureControllerTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/lecture/api/SearchLectureControllerTest.java
@@ -13,13 +13,18 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.plzgraduate.myongjigraduatebe.lecture.application.usecase.dto.SearchedLectureDto;
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.Lecture;
+import com.plzgraduate.myongjigraduatebe.parsing.api.TakenLectureCacheEvict;
 import com.plzgraduate.myongjigraduatebe.support.WebAdaptorTestSupport;
 import com.plzgraduate.myongjigraduatebe.support.WithMockAuthenticationUser;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 class SearchLectureControllerTest extends WebAdaptorTestSupport {
+
+	@MockBean
+	private TakenLectureCacheEvict takenLectureCacheEvict;
 
 	@WithMockAuthenticationUser
 	@DisplayName("type과 keyword를 통해 과목정보를 검색한다.")

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/parsing/api/ParsingTextControllerTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/parsing/api/ParsingTextControllerTest.java
@@ -15,10 +15,13 @@ import com.plzgraduate.myongjigraduatebe.support.WebAdaptorTestSupport;
 import com.plzgraduate.myongjigraduatebe.support.WithMockAuthenticationUser;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
 class ParsingTextControllerTest extends WebAdaptorTestSupport {
+	@MockBean
+	private TakenLectureCacheEvict takenLectureCacheEvict;
 
 	@WithMockAuthenticationUser
 	@DisplayName("파싱 텍스트를 등록한다.")

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/parsing/api/TakenLectureCacheEvictTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/parsing/api/TakenLectureCacheEvictTest.java
@@ -1,0 +1,33 @@
+package com.plzgraduate.myongjigraduatebe.parsing.api;
+
+import org.junit.jupiter.api.Test;
+
+import org.mockito.Mockito;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class TakenLectureCacheEvictTest {
+
+    @Test
+    void shouldSkipCacheEviction_whenProfileIsTest() {
+        // given
+        TakenLectureCacheEvict evict = new TakenLectureCacheEvict();
+        ReflectionTestUtils.setField(evict, "profile", "test");
+
+        // when
+        evict.evictTakenLecturesCache(1L); // 아무 예외도 발생하지 않아야 함
+
+        // then: 예외 없이 통과하면 성공
+    }
+
+    @Test
+    void shouldInvokeCacheEviction_whenProfileIsNotTest() {
+        // given
+        TakenLectureCacheEvict evict = Mockito.spy(new TakenLectureCacheEvict());
+        ReflectionTestUtils.setField(evict, "profile", "prod");
+
+        // when
+        evict.evictTakenLecturesCache(1L);
+
+        // then: 여기선 실제 CacheEvict 효과는 없지만 예외 없이 호출되는지만 확인
+    }
+}

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/support/TestCacheConfig.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/support/TestCacheConfig.java
@@ -1,0 +1,21 @@
+package com.plzgraduate.myongjigraduatebe.support;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+@EnableCaching
+@Profile("test")
+public class TestCacheConfig {
+
+    @Bean
+    @Primary
+    public CacheManager cacheManager() {
+        return new ConcurrentMapCacheManager("takenLectures");
+    }
+} 

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/takenlecture/api/find/FindTakenLectureControllerTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/takenlecture/api/find/FindTakenLectureControllerTest.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.Lecture;
+import com.plzgraduate.myongjigraduatebe.parsing.api.TakenLectureCacheEvict;
 import com.plzgraduate.myongjigraduatebe.support.WebAdaptorTestSupport;
 import com.plzgraduate.myongjigraduatebe.support.WithMockAuthenticationUser;
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.Semester;
@@ -17,8 +18,12 @@ import java.util.HashSet;
 import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 class FindTakenLectureControllerTest extends WebAdaptorTestSupport {
+
+	@MockBean
+	private TakenLectureCacheEvict takenLectureCacheEvict;
 
 	@WithMockAuthenticationUser
 	@DisplayName("사용자의 수강과목을 조회한다.")

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/takenlecture/api/update/UpdateTakenLectureControllerTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/takenlecture/api/update/UpdateTakenLectureControllerTest.java
@@ -6,14 +6,19 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.plzgraduate.myongjigraduatebe.parsing.api.TakenLectureCacheEvict;
 import com.plzgraduate.myongjigraduatebe.support.WebAdaptorTestSupport;
 import com.plzgraduate.myongjigraduatebe.support.WithMockAuthenticationUser;
 import com.plzgraduate.myongjigraduatebe.takenlecture.api.dto.request.GenerateCustomizedTakenLectureRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 
 class UpdateTakenLectureControllerTest extends WebAdaptorTestSupport {
+
+	@MockBean
+	private TakenLectureCacheEvict takenLectureCacheEvict;
 
 	@WithMockAuthenticationUser
 	@DisplayName("수강과목을 생성한다.")

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/user/api/findauthid/FindAuthIdControllerTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/user/api/findauthid/FindAuthIdControllerTest.java
@@ -9,11 +9,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.plzgraduate.myongjigraduatebe.parsing.api.TakenLectureCacheEvict;
 import com.plzgraduate.myongjigraduatebe.support.WebAdaptorTestSupport;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 class FindAuthIdControllerTest extends WebAdaptorTestSupport {
+
+	@MockBean
+	private TakenLectureCacheEvict takenLectureCacheEvict;
 
 	@DisplayName("학번으로 해당 학생의 아이디를 조회한다.")
 	@Test

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/user/api/finduserinformation/FindUserInformationControllerTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/user/api/finduserinformation/FindUserInformationControllerTest.java
@@ -6,14 +6,19 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.plzgraduate.myongjigraduatebe.parsing.api.TakenLectureCacheEvict;
 import com.plzgraduate.myongjigraduatebe.support.WebAdaptorTestSupport;
 import com.plzgraduate.myongjigraduatebe.support.WithMockAuthenticationUser;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.StudentCategory;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 class FindUserInformationControllerTest extends WebAdaptorTestSupport {
+
+	@MockBean
+	private TakenLectureCacheEvict takenLectureCacheEvict;
 
 	@WithMockAuthenticationUser
 	@DisplayName("로그인 한 회원 정보를 조회한다.")

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/user/api/resetpassword/ResetPasswordControllerTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/user/api/resetpassword/ResetPasswordControllerTest.java
@@ -10,14 +10,19 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.plzgraduate.myongjigraduatebe.parsing.api.TakenLectureCacheEvict;
 import com.plzgraduate.myongjigraduatebe.support.WebAdaptorTestSupport;
 import com.plzgraduate.myongjigraduatebe.user.api.resetpassword.dto.request.ResetPasswordRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
 class ResetPasswordControllerTest extends WebAdaptorTestSupport {
+
+	@MockBean
+	private TakenLectureCacheEvict takenLectureCacheEvict;
 
 	@DisplayName("학번으로 유저 정보 조회 후 로그인 이아디와 일치하는지 확인한다.")
 	@Test

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/user/api/signup/SignUpControllerTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/user/api/signup/SignUpControllerTest.java
@@ -10,16 +10,21 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.plzgraduate.myongjigraduatebe.parsing.api.TakenLectureCacheEvict;
 import com.plzgraduate.myongjigraduatebe.support.WebAdaptorTestSupport;
 import com.plzgraduate.myongjigraduatebe.user.api.signup.dto.request.SignUpRequest;
 import com.plzgraduate.myongjigraduatebe.user.api.signup.dto.response.AuthIdDuplicationResponse;
 import com.plzgraduate.myongjigraduatebe.user.api.signup.dto.response.StudentNumberDuplicationResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
 class SignUpControllerTest extends WebAdaptorTestSupport {
+
+	@MockBean
+	private TakenLectureCacheEvict takenLectureCacheEvict;
 
 	@DisplayName("회원가입을 진행한다.")
 	@Test

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/user/api/withdraw/WithDrawControllerTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/user/api/withdraw/WithDrawControllerTest.java
@@ -6,15 +6,20 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.plzgraduate.myongjigraduatebe.parsing.api.TakenLectureCacheEvict;
 import com.plzgraduate.myongjigraduatebe.support.WebAdaptorTestSupport;
 import com.plzgraduate.myongjigraduatebe.support.WithMockAuthenticationUser;
 import com.plzgraduate.myongjigraduatebe.user.api.withdraw.dto.request.WithDrawRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
 class WithDrawControllerTest extends WebAdaptorTestSupport {
+
+	@MockBean
+	private TakenLectureCacheEvict takenLectureCacheEvict;
 
 	@WithMockAuthenticationUser
 	@DisplayName("유저의 회원 탈퇴 요청을 수행한다.")


### PR DESCRIPTION
## Issue
	•	조회 API 응답 지연 및 반복 요청 시 성능 저하 현상
	•	Redis 캐싱 미적용 상태로 인한 DB 부하 발생

## ✅ 작업 내용
	•	@EnableCaching 추가 및 Redis 의존성 설정
	•	@Cacheable을 활용하여 수강과목 조회 캐싱 적용
	•	RedisCacheConfig 작성하여 TTL(10분) 설정
	•	수강과목 추가/삭제/파싱 시 @CacheEvict로 캐시 무효화 적용
	•	JMeter로 Redis 캐싱 적용 전후 성능 테스트 진행

## 테스트 내용
반복 부하 테스트(쓰레드:100, Ramp-up: 30, 루프카운트: 5)
로그인후 - 수강과목 조회

### 기존
![image](https://github.com/user-attachments/assets/931c6349-433b-45c6-abb4-039220a31262)

조회: 평균 1865ms 정도 

### Redis 적용후 테스트
![image](https://github.com/user-attachments/assets/c35d1158-c20b-4d57-8878-79dde18f7e0c)
- **수강과목 조회 평균 응답시간 5ms**
- 최대값도 32ms로 안정적
- 처리량도 16.7/sec
- 전체 평균도 37ms로 대폭 감소

## 🤔 고민 했던 부분
	반복 요청에 따른 DB 부담을 줄이기 위해 어떤 API에 캐싱을 적용할지 판단이 필요했음

## 🔊 도움이 필요한 부분!!
- 수강과목 외에 어떤 조회 API에도 캐싱을 적용할지에 대한 의견이 필요합니다
