### PR TITLE
[DEV-61] DB에 없는 수강과목 로그 저장 기능 구현

### DIFF
--- a/src/main/java/com/plzgraduate/myongjigraduatebe/log/application/port/LogInvalidLecturePort.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/log/application/port/LogInvalidLecturePort.java
@@ -1,0 +1,7 @@
+package com.plzgraduate.myongjigraduatebe.log.application.port;
+
+import com.plzgraduate.myongjigraduatebe.log.domain.InvalidTakenLectureLog;
+
+public interface LogInvalidLecturePort {
+    void saveLog(InvalidTakenLectureLog log);
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/log/application/service/LogInvalidLectureService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/log/application/service/LogInvalidLectureService.java
@@ -1,0 +1,22 @@
+package com.plzgraduate.myongjigraduatebe.log.application.service;
+
+import com.plzgraduate.myongjigraduatebe.log.application.port.LogInvalidLecturePort;
+import com.plzgraduate.myongjigraduatebe.log.application.usecase.LogInvalidLectureUseCase;
+import com.plzgraduate.myongjigraduatebe.log.domain.InvalidTakenLectureLog;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class LogInvalidLectureService implements LogInvalidLectureUseCase {
+
+    private final LogInvalidLecturePort logInvalidLecturePort;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Override
+    public void log(InvalidTakenLectureLog log) {
+        logInvalidLecturePort.saveLog(log);
+    }
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/log/application/usecase/LogInvalidLectureUseCase.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/log/application/usecase/LogInvalidLectureUseCase.java
@@ -1,0 +1,7 @@
+package com.plzgraduate.myongjigraduatebe.log.application.usecase;
+
+import com.plzgraduate.myongjigraduatebe.log.domain.InvalidTakenLectureLog;
+
+public interface LogInvalidLectureUseCase {
+    void log(InvalidTakenLectureLog log);
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/log/domain/InvalidTakenLectureLog.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/log/domain/InvalidTakenLectureLog.java
@@ -1,0 +1,25 @@
+package com.plzgraduate.myongjigraduatebe.log.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import java.time.LocalDateTime;
+
+@Getter
+public class InvalidTakenLectureLog {
+    private final String studentNumber;
+    private final String lectureCode;
+    private final String lectureName;
+    private final int year;
+    private final int semester;
+    private final LocalDateTime timestamp;
+
+    @Builder
+    public InvalidTakenLectureLog(String studentNumber, String lectureCode, String lectureName, int year, int semester, LocalDateTime timestamp) {
+        this.studentNumber = studentNumber;
+        this.lectureCode = lectureCode;
+        this.lectureName = lectureName;
+        this.year = year;
+        this.semester = semester;
+        this.timestamp = timestamp;
+    }
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/log/infrastructure/adapter/persistence/LogInvalidLecturePersistenceAdapter.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/log/infrastructure/adapter/persistence/LogInvalidLecturePersistenceAdapter.java
@@ -1,0 +1,30 @@
+package com.plzgraduate.myongjigraduatebe.log.infrastructure.adapter.persistence;
+
+
+import com.plzgraduate.myongjigraduatebe.core.meta.PersistenceAdapter;
+import com.plzgraduate.myongjigraduatebe.log.domain.InvalidTakenLectureLog;
+import com.plzgraduate.myongjigraduatebe.log.application.port.LogInvalidLecturePort;
+import com.plzgraduate.myongjigraduatebe.log.infrastructure.adapter.persistence.entity.InvalidTakenLectureLogEntity;
+import com.plzgraduate.myongjigraduatebe.log.infrastructure.adapter.persistence.repository.InvalidTakenLectureLogJpaRepository;
+import lombok.RequiredArgsConstructor;
+
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class LogInvalidLecturePersistenceAdapter implements LogInvalidLecturePort{
+    private final InvalidTakenLectureLogJpaRepository repository;
+
+    @Override
+    public void saveLog(InvalidTakenLectureLog log) {
+        InvalidTakenLectureLogEntity entity = InvalidTakenLectureLogEntity.builder()
+                .studentNumber(log.getStudentNumber())
+                .lectureCode(log.getLectureCode())
+                .lectureName(log.getLectureName())
+                .year(log.getYear())
+                .semester(log.getSemester())
+                .timestamp(log.getTimestamp())
+                .build();
+
+        repository.save(entity);
+    }
+
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/log/infrastructure/adapter/persistence/entity/InvalidTakenLectureLogEntity.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/log/infrastructure/adapter/persistence/entity/InvalidTakenLectureLogEntity.java
@@ -1,0 +1,26 @@
+package com.plzgraduate.myongjigraduatebe.log.infrastructure.adapter.persistence.entity;
+
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "invalid_taken_lecture_log")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder
+public class InvalidTakenLectureLogEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String studentNumber;
+    private String lectureCode;
+    private String lectureName;
+    private int year;
+    private int semester;
+    private LocalDateTime timestamp;
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/log/infrastructure/adapter/persistence/repository/InvalidTakenLectureLogJpaRepository.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/log/infrastructure/adapter/persistence/repository/InvalidTakenLectureLogJpaRepository.java
@@ -1,0 +1,7 @@
+package com.plzgraduate.myongjigraduatebe.log.infrastructure.adapter.persistence.repository;
+
+import com.plzgraduate.myongjigraduatebe.log.infrastructure.adapter.persistence.entity.InvalidTakenLectureLogEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InvalidTakenLectureLogJpaRepository extends JpaRepository<InvalidTakenLectureLogEntity, Long> {
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/application/service/ParsingTextService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/application/service/ParsingTextService.java
@@ -20,6 +20,7 @@ import com.plzgraduate.myongjigraduatebe.user.application.usecase.update.UpdateS
 import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
 import java.util.List;
 import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,7 +36,6 @@ class ParsingTextService implements ParsingTextUseCase {
 	private final SaveTakenLectureFromParsingTextUseCase saveTakenLectureFromParsingTextUseCase;
 	private final DeleteTakenLectureUseCase deleteTakenLectureByUserUseCase;
 	private final GenerateOrModifyCompletedCreditUseCase generateOrModifyCompletedCreditUseCase;
-
 	@Override
 	public void enrollParsingText(Long userId, String parsingText) {
 		User user = findUserUseCase.findUserById(userId);
@@ -92,7 +92,8 @@ class ParsingTextService implements ParsingTextUseCase {
 				TakenLectureInformation.createTakenLectureInformation(
 					parsingTakenLectureDto.getLectureCode(),
 					parsingTakenLectureDto.getYear(),
-					parsingTakenLectureDto.getSemester()
+					parsingTakenLectureDto.getSemester(),
+					parsingTakenLectureDto.getLectureName()
 				)
 			)
 			.collect(Collectors.toList());

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/domain/ParsingInformation.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/domain/ParsingInformation.java
@@ -159,12 +159,14 @@ public class ParsingInformation {
 			int year = Integer.parseInt(splitText[i + 1].split(" ")[0].substring(0, 4));
 			String semester = splitText[i + 1].split(" ")[1];
 			String code = splitText[i + 3];
+			String lectureName = splitText[i + 4];
 			char grade = splitText[i + 6].charAt(0);
 			if (grade != 'F' && grade != 'N' && grade != 'R') {
 				takenLectureInformation.add(ParsingTakenLectureDto.of(
 						code,
 						year,
-						Semester.of(semester)
+						Semester.of(semester),
+						lectureName
 				));
 			}
 			if (i + 7 < splitText.length && Character.isDigit(splitText[i + 7].charAt(0))) {

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/domain/ParsingTakenLectureDto.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/domain/ParsingTakenLectureDto.java
@@ -10,23 +10,27 @@ public class ParsingTakenLectureDto {
 	private final String lectureCode;
 	private final int year;
 	private final Semester semester;
+	private final String lectureName;
 
 	@Builder
 	private ParsingTakenLectureDto(
 		String lectureCode,
 		int year,
-		Semester semester
+		Semester semester,
+		String lectureName
 	) {
 		this.lectureCode = lectureCode;
 		this.year = year;
 		this.semester = semester;
+		this.lectureName = lectureName;
 	}
 
-	public static ParsingTakenLectureDto of(String lectureCode, int year, Semester semester) {
+	public static ParsingTakenLectureDto of(String lectureCode, int year, Semester semester, String lectureName) {
 		return ParsingTakenLectureDto.builder()
 			.lectureCode(lectureCode)
 			.year(year)
 			.semester(semester)
+			.lectureName(lectureName)
 			.build();
 	}
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/takenlecture/domain/model/Semester.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/takenlecture/domain/model/Semester.java
@@ -9,11 +9,12 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum Semester {
-	FIRST("1학기"),
-	SUMMER("하계계절"),
-	SECOND("2학기"),
-	WINTER("동계계절");
+	FIRST(1, "1학기"),
+	SUMMER(2, "하계계절"),
+	SECOND(3, "2학기"),
+	WINTER(4, "동계계절");
 
+	private final int value;
 	private final String name;
 
 	public static Semester of(String name) {

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/takenlecture/domain/model/TakenLectureInformation.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/takenlecture/domain/model/TakenLectureInformation.java
@@ -9,20 +9,23 @@ public class TakenLectureInformation {
 	private final String lectureCode;
 	private final int year;
 	private final Semester semester;
+	private final String lectureName;
 
 	@Builder
-	private TakenLectureInformation(String lectureCode, int year, Semester semester) {
+	private TakenLectureInformation(String lectureCode, int year, Semester semester, String lectureName) {
 		this.lectureCode = lectureCode;
 		this.year = year;
 		this.semester = semester;
-	}
+        this.lectureName = lectureName;
+    }
 
 	public static TakenLectureInformation createTakenLectureInformation(String lectureCode,
-		int year, Semester semester) {
+		int year, Semester semester, String lectureName) {
 		return TakenLectureInformation.builder()
 			.lectureCode(lectureCode)
 			.year(year)
 			.semester(semester)
+			.lectureName(lectureName)
 			.build();
 	}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -72,7 +72,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: update
 
   redis:
     host: localhost

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/log/application/service/LogInvalidLectureServiceTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/log/application/service/LogInvalidLectureServiceTest.java
@@ -1,0 +1,44 @@
+package com.plzgraduate.myongjigraduatebe.log.application.service;
+
+import com.plzgraduate.myongjigraduatebe.log.application.port.LogInvalidLecturePort;
+import com.plzgraduate.myongjigraduatebe.log.domain.InvalidTakenLectureLog;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.Mockito.mock;
+
+
+class LogInvalidLectureServiceTest {
+
+    private LogInvalidLecturePort logInvalidLecturePort;
+    private LogInvalidLectureService logInvalidLectureService;
+
+    @BeforeEach
+    void setUp() {
+        logInvalidLecturePort = mock(LogInvalidLecturePort.class);
+        logInvalidLectureService = new LogInvalidLectureService(logInvalidLecturePort);
+    }
+
+    @Test
+    void 로그가_정상적으로_저장된다() {
+        // given
+        InvalidTakenLectureLog log = InvalidTakenLectureLog.builder()
+                .studentNumber("60231215")
+                .lectureCode("UNKNOWN02101")
+                .lectureName("없는강의")
+                .year(2023)
+                .semester(1)
+                .timestamp(LocalDateTime.now())
+                .build();
+
+        // when
+        logInvalidLectureService.log(log);
+
+        // then
+        verify(logInvalidLecturePort, times(1)).saveLog(log); // 정확히 1회 호출되었는지 확인
+    }
+}


### PR DESCRIPTION


## ✅ 작업 내용
	•	DB에 존재하지 않는 수강 과목이 파싱 시 포함될 경우, 저장은 하지 않되 로그는 별도로 저장되도록 처리
	•	LogInvalidLectureService는 @Transactional(propagation = REQUIRES_NEW)로 설정하여 메인 트랜잭션 롤백과 무관하게 로그는 항상 저장되도록 구성
	•	로그 저장 관련 테스트 코드(LogInvalidLectureServiceTest, 예외 발생 테스트) 작성
	•	TakenLectureInformation, ParsingTakenLectureDto 등에 과목명을 포함하도록 변경하여 로그에 과목명 기록 가능하도록 개선


## 🤔 고민했던 부분
	•	트랜잭션 롤백 시 로그까지 같이 롤백될 수 있는 구조를 피하고 싶었기 때문에, 로그 저장 로직은 별도 트랜잭션으로 분리 (REQUIRES_NEW)
	•	lectureName을 TakenLectureInformation에 포함시켜야 로그 저장 시 정보를 최대한 보존할 수 있어 구조를 일부 확장
	•	실제 수강 내역 저장은 실패하더라도, 어떤 과목에서 실패했는지 명확히 추적 가능해야 하기 때문에 예외 전후 흐름을 세밀히 조절했습니다

## 🔊 도움이 필요한 부분!!
* 추후 지금은 없는 과목이 나오면 저장하지 않고 롤백 되지만 사용자 입장에서는 바로 이용이 불가함 있는 과목만 저장하고 없는과목은 사용자가 임의로 추가 가능 하게 할지에 대한 논의 필요해보임
* 추가 로그 저장으로는 기존 성적표에 이수학점과 졸부 로직의 이수학점을 비교하여 오차가 있을시 로그 저장하는거에 대해 생각해 볼 필요가 있음
<img width="954" height="30" alt="image" src="https://github.com/user-attachments/assets/0b8afb67-36de-4136-9ff7-3a8f7a4a8c2f" />
