### PR TITLE
[DEV-65] 커스텀 과목수정 업데이트 문제 수정

### DIFF
--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateGraduationService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/application/service/CalculateGraduationService.java
@@ -42,15 +42,12 @@ class CalculateGraduationService implements CalculateGraduationUseCase {
 		TakenLectureInventory takenLectureInventory = findTakenLectureUseCase.findTakenLectures(
 			user.getId()
 		);
-
 		List<DetailGraduationResult> detailGraduationResults = generateDetailGraduationResults(
 			user,
 			takenLectureInventory,
 			graduationRequirement
 		);
-
 		ChapelResult chapelResult = generateChapelResult(user, takenLectureInventory);
-
 		GraduationResult graduationResult = generateGraduationResult(
 			chapelResult,
 			detailGraduationResults,

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/takenlecture/api/UpdateTakenLectureController.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/takenlecture/api/UpdateTakenLectureController.java
@@ -3,7 +3,6 @@ package com.plzgraduate.myongjigraduatebe.takenlecture.api;
 import com.plzgraduate.myongjigraduatebe.core.meta.LoginUser;
 import com.plzgraduate.myongjigraduatebe.core.meta.WebAdapter;
 
-import com.plzgraduate.myongjigraduatebe.parsing.api.TakenLectureCacheEvict;
 import com.plzgraduate.myongjigraduatebe.takenlecture.api.dto.request.GenerateCustomizedTakenLectureRequest;
 import com.plzgraduate.myongjigraduatebe.takenlecture.application.usecase.delete.DeleteTakenLectureUseCase;
 import com.plzgraduate.myongjigraduatebe.takenlecture.application.usecase.save.GenerateCustomizedTakenLectureUseCase;
@@ -22,20 +21,17 @@ public class UpdateTakenLectureController implements UpdateTakenLectureApiPresen
 
 	private final GenerateCustomizedTakenLectureUseCase generateCustomizedTakenLectureUseCase;
 	private final DeleteTakenLectureUseCase deleteTakenLectureUseCase;
-	private final TakenLectureCacheEvict takenLectureCacheEvict;
 
 	@PostMapping()
 	public void generateCustomizedTakenLecture(@LoginUser Long userId,
 		@Valid @RequestBody GenerateCustomizedTakenLectureRequest generateCustomizedTakenLectureRequest) {
 		generateCustomizedTakenLectureUseCase.generateCustomizedTakenLecture(userId,
 			generateCustomizedTakenLectureRequest.getLectureId());
-		takenLectureCacheEvict.evictTakenLecturesCache(userId);
 	}
 
 	@DeleteMapping("{takenLectureId}")
 	public void deleteCustomizedTakenLecture(@LoginUser Long userId,
 		@Valid @PathVariable Long takenLectureId) {
 		deleteTakenLectureUseCase.deleteTakenLecture(userId, takenLectureId);
-		takenLectureCacheEvict.evictTakenLecturesCache(userId);
 	}
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/takenlecture/application/service/delete/DeleteTakenLectureService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/takenlecture/application/service/delete/DeleteTakenLectureService.java
@@ -8,15 +8,23 @@ import com.plzgraduate.myongjigraduatebe.user.application.usecase.find.FindUserU
 import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
+import com.plzgraduate.myongjigraduatebe.takenlecture.application.port.FindTakenLecturePort;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLecture;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
+import com.plzgraduate.myongjigraduatebe.parsing.api.TakenLectureCacheEvict;
+import java.util.List;
+import java.util.HashSet;
 
 @UseCase
 @Transactional
 @RequiredArgsConstructor
-class DeleteTakenLectureService implements DeleteTakenLectureUseCase {
+public class DeleteTakenLectureService implements DeleteTakenLectureUseCase {
 
 	private final FindUserUseCase findUserUseCase;
+	private final FindTakenLecturePort findTakenLecturePort;
 	private final DeleteTakenLecturePort deleteTakenLecturePort;
 	private final GenerateOrModifyCompletedCreditUseCase generateOrModifyCompletedCreditUseCase;
+	private final TakenLectureCacheEvict takenLectureCacheEvict;
 
 	@Override
 	public void deleteAllTakenLecturesByUser(User user) {
@@ -24,9 +32,24 @@ class DeleteTakenLectureService implements DeleteTakenLectureUseCase {
 	}
 
 	@Override
-	public void deleteTakenLecture(Long userId, Long deletedTakenLectureId) {
+	public void deleteTakenLecture(final Long userId, final Long takenLectureId) {
 		User user = findUserUseCase.findUserById(userId);
-		deleteTakenLecturePort.deleteTakenLectureById(deletedTakenLectureId);
+		
+		// 삭제할 과목 정보 찾기
+		List<TakenLecture> beforeTakenLectures = findTakenLecturePort.findTakenLecturesByUser(user);
+		TakenLectureInventory beforeTakenLectureInventory = TakenLectureInventory.from(new HashSet<>(beforeTakenLectures));
+		
+		TakenLecture takenLectureToDelete = beforeTakenLectureInventory.getTakenLectures().stream()
+			.filter(taken -> taken.getId().equals(takenLectureId))
+			.findFirst()
+			.orElseThrow(() -> new IllegalArgumentException("삭제할 과목을 찾을 수 없습니다: " + takenLectureId));
+		
+		deleteTakenLecturePort.deleteTakenLectureById(takenLectureId);
+		
+		// 캐시 무효화 (학점 재계산 전에 수행)
+		takenLectureCacheEvict.evictTakenLecturesCache(userId);
+		
+		// 학점 재계산
 		generateOrModifyCompletedCreditUseCase.generateOrModifyCompletedCredit(user);
 	}
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/takenlecture/application/service/find/FindTakenLectureService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/takenlecture/application/service/find/FindTakenLectureService.java
@@ -19,7 +19,6 @@ import org.springframework.cache.annotation.Cacheable;
 class FindTakenLectureService implements FindTakenLectureUseCase {
 
 	private final FindUserUseCase findUserUseCase;
-
 	private final FindTakenLecturePort findTakenLecturePort;
 
 	@Override

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/takenlecture/application/service/save/GenerateCustomizedTakenLectureService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/takenlecture/application/service/save/GenerateCustomizedTakenLectureService.java
@@ -5,7 +5,6 @@ import com.plzgraduate.myongjigraduatebe.core.meta.UseCase;
 import com.plzgraduate.myongjigraduatebe.lecture.application.port.FindLecturePort;
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.Lecture;
 import com.plzgraduate.myongjigraduatebe.parsing.api.TakenLectureCacheEvict;
-import com.plzgraduate.myongjigraduatebe.takenlecture.application.port.FindTakenLecturePort;
 import com.plzgraduate.myongjigraduatebe.takenlecture.application.port.SaveTakenLecturePort;
 import com.plzgraduate.myongjigraduatebe.takenlecture.application.usecase.save.GenerateCustomizedTakenLectureUseCase;
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLecture;

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/takenlecture/application/service/delete/DeleteTakenLectureServiceTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/takenlecture/application/service/delete/DeleteTakenLectureServiceTest.java
@@ -1,12 +1,17 @@
 package com.plzgraduate.myongjigraduatebe.takenlecture.application.service.delete;
 
 import static org.mockito.BDDMockito.eq;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
 import com.plzgraduate.myongjigraduatebe.completedcredit.application.usecase.GenerateOrModifyCompletedCreditUseCase;
+import com.plzgraduate.myongjigraduatebe.parsing.api.TakenLectureCacheEvict;
 import com.plzgraduate.myongjigraduatebe.takenlecture.application.port.DeleteTakenLecturePort;
+import com.plzgraduate.myongjigraduatebe.takenlecture.application.port.FindTakenLecturePort;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLecture;
 import com.plzgraduate.myongjigraduatebe.user.application.usecase.find.FindUserUseCase;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,24 +29,37 @@ class DeleteTakenLectureServiceTest {
 	private DeleteTakenLecturePort deleteTakenLecturePort;
 
 	@Mock
+	private TakenLectureCacheEvict takenLectureCacheEvict;
+
+	@Mock
 	private GenerateOrModifyCompletedCreditUseCase generateOrModifyCompletedCreditUseCase;
+
+	@Mock
+	private FindTakenLecturePort findTakenLecturePort;
 
 	@InjectMocks
 	private DeleteTakenLectureService deleteTakenLectureService;
 
-	@DisplayName("수강과목을 삭제한다.")
 	@Test
 	void deleteTakenLecture() {
 		//given
 		Long userId = 1L;
 		Long deletedTakenLectureId = 102L;
+		User user = User.builder().build();
+		TakenLecture takenLecture = TakenLecture.builder()
+			.id(deletedTakenLectureId)
+			.user(user)
+			.build();
+
+		given(findUserUseCase.findUserById(userId)).willReturn(user);
+		given(findTakenLecturePort.findTakenLecturesByUser(user)).willReturn(List.of(takenLecture));
 
 		//when
 		deleteTakenLectureService.deleteTakenLecture(userId, deletedTakenLectureId);
 
 		//then
 		then(deleteTakenLecturePort).should()
-			.deleteTakenLectureById(102L);
+			.deleteTakenLectureById(deletedTakenLectureId);
 	}
 
 	@DisplayName("사용자의 모든 수강과목을 삭제한다.")

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/takenlecture/application/service/save/GenerateTakenLectureServiceTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/takenlecture/application/service/save/GenerateTakenLectureServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.BDDMockito.then;
 import com.plzgraduate.myongjigraduatebe.completedcredit.application.usecase.GenerateOrModifyCompletedCreditUseCase;
 import com.plzgraduate.myongjigraduatebe.lecture.application.port.FindLecturePort;
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.Lecture;
+import com.plzgraduate.myongjigraduatebe.parsing.api.TakenLectureCacheEvict;
 import com.plzgraduate.myongjigraduatebe.takenlecture.application.port.SaveTakenLecturePort;
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLecture;
 import com.plzgraduate.myongjigraduatebe.user.application.usecase.find.FindUserUseCase;
@@ -29,6 +30,8 @@ class GenerateTakenLectureServiceTest {
 	private SaveTakenLecturePort saveTakenLecturePort;
 	@Mock
 	private GenerateOrModifyCompletedCreditUseCase generateOrModifyCompletedCreditUseCase;
+	@Mock
+	private TakenLectureCacheEvict takenLectureCacheEvict;
 	@InjectMocks
 	private GenerateCustomizedTakenLectureService generateTakenLectureService;
 


### PR DESCRIPTION
## ✅ 작업 내용
- 커스텀 과목 추가/삭제 시 학점이 반영되지 않는 문제 해결
- GenerateCustomizedTakenLectureService에서 캐시 무효화 → 학점 재계산 순서로 
- DeleteTakenLectureService에서도 동일하게 캐시 무효화 후 학점 재계산 수행
- UpdateTakenLectureController에서 중복 캐시 무효화 제거

## 🤔 고민 했던 부분
- 커스텀 과목 처리 시 학점 계산이 되지 않아, 실제 completedCredit 테이블이 갱신되지 않는 현상이 발생함
- 원인을 추적해보니, 학점 재계산 전에 Redis 캐시(takenLectures::userId)가 유지되어 잘못된 값으로 계산되고 있었음
- generateOrModifyCompletedCreditUseCase 호출 전에 반드시 takenLectureCacheEvict가 선행되어야 함을 확인함
- 테스트 코드에서는 삭제 대상 과목 존재 여부 확인이 실패 원인이 되었고, 사전 조회 및 예외 처리를 유지하며 Mock을 통해 테스트 보완함
