### PR TITLE
[DEV-67] 성적표 업데이트에 따른 pdf 파싱 수정

### DIFF
--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/commonculture/CommonGraduationManager.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/commonculture/CommonGraduationManager.java
@@ -11,6 +11,7 @@ import com.plzgraduate.myongjigraduatebe.lecture.domain.model.CommonCulture;
 import com.plzgraduate.myongjigraduatebe.lecture.domain.model.CommonCultureCategory;
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.ExchangeCredit;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -22,39 +23,45 @@ public class CommonGraduationManager implements GraduationManager<CommonCulture>
 
 	@Override
 	public DetailGraduationResult createDetailGraduationResult(
-		User user,
-		TakenLectureInventory takenLectureInventory,
-		Set<CommonCulture> graduationLectures,
-		int commonCultureGraduationTotalCredit
+			User user,
+			TakenLectureInventory takenLectureInventory,
+			Set<CommonCulture> graduationLectures,
+			int commonCultureGraduationTotalCredit
 	) {
 		CommonCultureDetailCategoryManager commonCultureDetailCategoryManager = new CommonCultureDetailCategoryManager();
 		List<DetailCategoryResult> commonCultureDetailCategoryResults =
-			Arrays.stream(CommonCultureCategory.values())
-				.filter(commonCultureCategory -> commonCultureCategory.isContainsEntryYear(user.getEntryYear()))
-				.map(commonCultureCategory -> commonCultureDetailCategoryManager.generate(
-					user,
-					takenLectureInventory,
-					graduationLectures,
-					commonCultureCategory
-				))
-				.collect(Collectors.toList());
+				Arrays.stream(CommonCultureCategory.values())
+						.filter(commonCultureCategory -> commonCultureCategory.isContainsEntryYear(user.getEntryYear()))
+						.map(commonCultureCategory -> commonCultureDetailCategoryManager.generate(
+								user,
+								takenLectureInventory,
+								graduationLectures,
+								commonCultureCategory
+						))
+						.collect(Collectors.toList());
 
 		DetailGraduationResult detailGraduationResult = DetailGraduationResult.create(
-			COMMON_CULTURE,
-			commonCultureGraduationTotalCredit,
-			commonCultureDetailCategoryResults
+				COMMON_CULTURE,
+				commonCultureGraduationTotalCredit,
+				commonCultureDetailCategoryResults
 		);
 		detailGraduationResult.addCredit(getTakenChapelCredits(takenLectureInventory));
+		detailGraduationResult.addCredit(getExchangeCommonCultureCredit(user));
 		return detailGraduationResult;
 	}
 
 	private double getTakenChapelCredits(TakenLectureInventory takenLectureInventory) {
 		int chapelCount = (int) takenLectureInventory.getTakenLectures()
-			.stream()
-			.filter(takenLecture -> takenLecture.getLecture()
-				.getId()
-				.equals(CHAPEL_LECTURE_CODE))
-			.count();
+				.stream()
+				.filter(takenLecture -> takenLecture.getLecture()
+						.getId()
+						.equals(CHAPEL_LECTURE_CODE))
+				.count();
 		return chapelCount * CHAPEL_CREDIT;
+	}
+
+	private double getExchangeCommonCultureCredit(User user) {
+		ExchangeCredit ec = user.getExchangeCredit();
+		return (ec == null) ? 0 : ec.getCommonCulture();
 	}
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/domain/model/ExchangeCredit.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/domain/model/ExchangeCredit.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 public class ExchangeCredit implements Serializable {
     private static final long serialVersionUID = 1L;
 
+    private int commonCulture;            //공통교양
     private int basicAcademicalCulture;  // 학문기초교양
     private int normalCulture;          // 일반교양
     private int major;                  // 전공
@@ -22,31 +23,62 @@ public class ExchangeCredit implements Serializable {
     private int freeElective;           // 자유선택
 
     public static ExchangeCredit empty() {
-        return new ExchangeCredit(0, 0, 0, 0, 0, 0, 0, 0);
+        return new ExchangeCredit(0, 0, 0, 0, 0, 0, 0, 0, 0);
     }
 
     public static ExchangeCredit from(String input) {
-        if (isValid(input)) {
-            String[] parts = input.split("/");
-            int basicAcademicalCulture = Integer.parseInt(parts[0]);
-            int normalCulture = Integer.parseInt(parts[1]);
-            int major = Integer.parseInt(parts[2]);
-            int dualBasicAcademicalCulture = Integer.parseInt(parts[3]);
-            int dualMajor = Integer.parseInt(parts[4]);
-            int fusionMajor = Integer.parseInt(parts[5]);
-            int subMajor = Integer.parseInt(parts[6]);
-            int freeElective = Integer.parseInt(parts[7]);
+        // 허용 입력:
+        // - null/blank          -> empty()
+        // - "0"                 -> empty() (레거시/디폴트 표기)
+        // - "a/b/c/d/e/f/g/h"   -> 8개(레거시, 공통교양 없음)
+        // - "a/b/c/d/e/f/g/h/i" -> 9개(신규, 공통교양 포함)
+        if (input == null) {
+            return ExchangeCredit.empty();
+        }
+        String trimmed = input.trim();
+        if (trimmed.isEmpty() || "0".equals(trimmed)) {
+            return ExchangeCredit.empty();
+        }
 
-            return new ExchangeCredit(basicAcademicalCulture, normalCulture, major,
-                    dualBasicAcademicalCulture, dualMajor, fusionMajor, subMajor, freeElective);
-        } else {
-            throw new IllegalArgumentException("잘못된 형식입니다.");
+        String[] parts = trimmed.split("/");
+        try {
+            if (parts.length == 9) {
+                int commonCulture = Integer.parseInt(parts[0]);
+                int basicAcademicalCulture = Integer.parseInt(parts[1]);
+                int normalCulture = Integer.parseInt(parts[2]);
+                int major = Integer.parseInt(parts[3]);
+                int dualBasicAcademicalCulture = Integer.parseInt(parts[4]);
+                int dualMajor = Integer.parseInt(parts[5]);
+                int fusionMajor = Integer.parseInt(parts[6]);
+                int subMajor = Integer.parseInt(parts[7]);
+                int freeElective = Integer.parseInt(parts[8]);
+                return new ExchangeCredit(commonCulture, basicAcademicalCulture, normalCulture, major,
+                        dualBasicAcademicalCulture, dualMajor, fusionMajor, subMajor, freeElective);
+            } else if (parts.length == 8) {
+                // 레거시 포맷(공통교양 미포함): [학문기초, 일반교양, 전공, 복수기초, 복수전공, 융합, 부전공, 자유선택]
+                int commonCulture = 0;
+                int basicAcademicalCulture = Integer.parseInt(parts[0]);
+                int normalCulture = Integer.parseInt(parts[1]);
+                int major = Integer.parseInt(parts[2]);
+                int dualBasicAcademicalCulture = Integer.parseInt(parts[3]);
+                int dualMajor = Integer.parseInt(parts[4]);
+                int fusionMajor = Integer.parseInt(parts[5]);
+                int subMajor = Integer.parseInt(parts[6]);
+                int freeElective = Integer.parseInt(parts[7]);
+                return new ExchangeCredit(commonCulture, basicAcademicalCulture, normalCulture, major,
+                        dualBasicAcademicalCulture, dualMajor, fusionMajor, subMajor, freeElective);
+            } else {
+                throw new IllegalArgumentException("교환학생 인정학점 형식 오류: 필드 개수=" + parts.length + " (허용: 8 또는 9, 또는 \"0\")");
+            }
+        } catch (NumberFormatException ex) {
+            throw new IllegalArgumentException("교환학생 인정학점 숫자 파싱 오류: " + trimmed, ex);
         }
     }
 
     private static boolean isValid(String input) {
-        // 8개의 숫자가 '/'로 구분된 형식인지 확인
-        return input.matches("^\\d+/\\d+/\\d+/\\d+/\\d+/\\d+/\\d+/\\d+$");
+        if (input == null) return false;
+        // 숫자 8개 (슬래시 7개) 또는 9개 (슬래시 8개) 허용
+        return input.matches("^\\d+(/\\d+){7,8}$");
     }
 
     @Override
@@ -58,7 +90,8 @@ public class ExchangeCredit implements Serializable {
             return false;
         }
         ExchangeCredit that = (ExchangeCredit) o;
-        return basicAcademicalCulture == that.basicAcademicalCulture &&
+        return  commonCulture == that.commonCulture &&
+                basicAcademicalCulture == that.basicAcademicalCulture &&
                 normalCulture == that.normalCulture &&
                 major == that.major &&
                 dualBasicAcademicalCulture == that.dualBasicAcademicalCulture &&
@@ -70,13 +103,14 @@ public class ExchangeCredit implements Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(basicAcademicalCulture, normalCulture, major,
+        return Objects.hash(commonCulture, basicAcademicalCulture, normalCulture, major,
                 dualBasicAcademicalCulture, dualMajor, fusionMajor, subMajor, freeElective);
     }
 
     @Override
     public String toString() {
-        return basicAcademicalCulture + "/"
+        return  commonCulture + "/"
+                + basicAcademicalCulture + "/"
                 + normalCulture + "/"
                 + major + "/"
                 + dualBasicAcademicalCulture + "/"

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/user/application/service/update/UpdateStudentInformationServiceTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/user/application/service/update/UpdateStudentInformationServiceTest.java
@@ -82,7 +82,7 @@ class UpdateStudentInformationServiceTest {
 				.exchangeCredit(ExchangeCredit.empty())
 				.build();
 
-		ExchangeCredit exchangeCredit = new ExchangeCredit(3,3,3,3,3,3,3,3);
+		ExchangeCredit exchangeCredit = new ExchangeCredit(3,3,3,3,3,3,3,3,3);
 
 		UpdateStudentInformationCommand command = UpdateStudentInformationCommand.builder()
 				.user(user)

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/user/infrastructure/adapter/persistence/UserPersistenceAdapterTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/user/infrastructure/adapter/persistence/UserPersistenceAdapterTest.java
@@ -119,7 +119,7 @@ class UserPersistenceAdapterTest extends PersistenceTestSupport {
 				.password("1q2w3e4r!")
 				.studentNumber("60181666")
 				.transferCredit(new TransferCredit(0, 0, 0, 0))
-				.exchangeCredit(new ExchangeCredit(0, 0, 0, 0, 0, 0, 0, 0))
+				.exchangeCredit(new ExchangeCredit(0, 0, 0, 0, 0, 0, 0, 0,0))
 				.studentCategory(StudentCategory.NORMAL)
 				.build();
 	}

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/user/infrastructure/adapter/persistence/mapper/UserMapperTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/user/infrastructure/adapter/persistence/mapper/UserMapperTest.java
@@ -59,7 +59,7 @@ class UserMapperTest extends PersistenceTestSupport {
 		assertThat(userJpaEntity.getTransferCredit())
 				.isEqualTo("0/0/0/0");
 		assertThat(userJpaEntity.getExchangeCredit())
-				.isEqualTo("0/0/0/0/0/0/0/0");
+				.isEqualTo("0/0/0/0/0/0/0/0/0");
 	}
 
 	private User createUser() {
@@ -75,7 +75,7 @@ class UserMapperTest extends PersistenceTestSupport {
 			.dualMajor(null)
 			.subMajor(null)
 			.transferCredit(TransferCredit.from("0/0/0/0"))
-			.exchangeCredit(ExchangeCredit.from("0/0/0/0/0/0/0/0"))
+			.exchangeCredit(ExchangeCredit.from("0/0/0/0/0/0/0/0/0"))
 			.totalCredit(100)
 			.takenCredit(40)
 			.graduated(false)
@@ -97,7 +97,7 @@ class UserMapperTest extends PersistenceTestSupport {
 				.subMajor(null)
 				.associatedMajor(null)
 				.transferCredit("0/0/0/0") // 기본값 설정
-				.exchangeCredit("0/0/0/0/0/0/0/0") //기본값 설정
+				.exchangeCredit("0/0/0/0/0/0/0/0/0") //기본값 설정
 				.studentCategory(StudentCategory.NORMAL)
 				.totalCredit(100)
 				.takenCredit(40.0)


### PR DESCRIPTION

## ✅ 작업 내용
- 성적표 pdf에서 교환학생의 공통교양이 추가되며 pdf 인식 문제가 발생하여 해당부분을 추가하여 수정

## 🤔 고민 했던 부분
- 기존 성적표와 새로운 성적표 모두 이용할 수 있게 하기위해 조건문으로 처리, 별도의 DB마이그레이션 없이 새로운 성적표 업로드시 변환

