### PR TITLE
[DEV-76] 강좌정보/강좌평 조회 API  공개 경로 허용 수정

### DIFF
--- a/src/main/java/com/plzgraduate/myongjigraduatebe/core/config/SecurityConfig.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/core/config/SecurityConfig.java
@@ -51,6 +51,8 @@ public class SecurityConfig {
 				API_V1_PREFIX + "/graduations/check", // 비로그인 졸업 요건 검사
 				API_V1_PREFIX + "/timetable/**", // 시간표 강의 조회
                 API_V1_PREFIX + "/lectures/popular/**", //인기 강의 조회
+				API_V1_PREFIX + "/lectures-info", // 강좌 정보 조회
+				API_V1_PREFIX + "/lecture-reviews", //강좌평 조회
 				"/api-docs",
 				"/swagger-custom-ui.html",
 				"/v3/api-docs/**",


### PR DESCRIPTION
## Issue

## ✅ 작업 내용
- 강좌정보/강좌평 조회 API 엔드포인트를 인증 없이 접근 가능하도록 변경
