### PR TITLE
[DEV-100] 비회원 졸업검사 졸업 결과 오류 수정

### DIFF
--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/api/CheckGraduationRequirementController.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/api/CheckGraduationRequirementController.java
@@ -39,7 +39,7 @@ public class CheckGraduationRequirementController implements CheckGraduationRequ
 		);
 
 		return new CheckGraduationRequirementResponse(
-			UserInformationResponse.from(anonymous),
+			UserInformationResponse.of(anonymous, graduationResult),
 			graduationResult
 		);
 	}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/user/api/finduserinformation/dto/response/UserInformationResponse.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/user/api/finduserinformation/dto/response/UserInformationResponse.java
@@ -1,5 +1,6 @@
 package com.plzgraduate.myongjigraduatebe.user.api.finduserinformation.dto.response;
 
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationResult;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.ArrayList;
@@ -38,6 +39,29 @@ public class UserInformationResponse {
 			.totalCredit(user.getTotalCredit())
 			.takenCredit(user.getTakenCredit())
 			.graduated(user.isGraduated())
+			.build();
+		if (user.getPrimaryMajor() != null) {
+			userInformation.getCompleteDivision()
+				.add(CompleteDivisionResponse.of("PRIMARY", user.getPrimaryMajor()));
+		}
+		if (user.getDualMajor() != null) {
+			userInformation.getCompleteDivision()
+				.add(CompleteDivisionResponse.of("DUAL", user.getDualMajor()));
+		}
+		if (user.getSubMajor() != null) {
+			userInformation.getCompleteDivision()
+				.add(CompleteDivisionResponse.of("SUB", user.getSubMajor()));
+		}
+		return userInformation;
+	}
+
+	public static UserInformationResponse of(User user, GraduationResult graduationResult) {
+		UserInformationResponse userInformation = UserInformationResponse.builder()
+			.studentNumber(user.getStudentNumber())
+			.studentName(user.getName())
+			.totalCredit(graduationResult.getTotalCredit())
+			.takenCredit(graduationResult.getTakenCredit())
+			.graduated(graduationResult.isGraduated())
 			.build();
 		if (user.getPrimaryMajor() != null) {
 			userInformation.getCompleteDivision()

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/api/CheckGraduationRequirementControllerTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/api/CheckGraduationRequirementControllerTest.java
@@ -1,0 +1,94 @@
+package com.plzgraduate.myongjigraduatebe.graduation.api;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.plzgraduate.myongjigraduatebe.graduation.api.dto.request.CheckGraduationRequirementRequest;
+import com.plzgraduate.myongjigraduatebe.graduation.application.usecase.CheckGraduationRequirementUseCase;
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationResult;
+import com.plzgraduate.myongjigraduatebe.parsing.application.usecase.ParsingAnonymousUseCase;
+import com.plzgraduate.myongjigraduatebe.parsing.application.usecase.dto.ParsingAnonymousDto;
+import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.EnglishLevel;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.KoreanLevel;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@ActiveProfiles("test")
+@WebMvcTest(CheckGraduationRequirementController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class CheckGraduationRequirementControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockBean
+	private ParsingAnonymousUseCase parsingAnonymousUseCase;
+
+	@MockBean
+	private CheckGraduationRequirementUseCase checkGraduationRequirementUseCase;
+
+	@DisplayName("비회원 졸업진단 응답의 user 정보는 계산된 졸업 결과를 반영한다.")
+	@Test
+	void checkGraduationRequirementUsesGraduationResultForUserInfo() throws Exception {
+		CheckGraduationRequirementRequest request = CheckGraduationRequirementRequest.builder()
+			.engLv("ENG34")
+			.korLv("FREE")
+			.parsingText("mock parsing text")
+			.build();
+
+		User anonymous = User.builder()
+			.authId("anonymous")
+			.name("방현우")
+			.studentNumber("60190872")
+			.primaryMajor("국제통상학과")
+			.dualMajor("경영정보학과")
+			.totalCredit(0)
+			.takenCredit(0)
+			.graduated(false)
+			.build();
+
+		ParsingAnonymousDto parsingAnonymousDto = new ParsingAnonymousDto(
+			anonymous,
+			TakenLectureInventory.from(Set.of())
+		);
+
+		GraduationResult graduationResult = GraduationResult.builder()
+			.totalCredit(128)
+			.takenCredit(133)
+			.graduated(true)
+			.build();
+
+		given(parsingAnonymousUseCase.parseAnonymous(EnglishLevel.ENG34, KoreanLevel.FREE, "mock parsing text"))
+			.willReturn(parsingAnonymousDto);
+		given(checkGraduationRequirementUseCase.checkGraduationRequirement(any(User.class), any(TakenLectureInventory.class)))
+			.willReturn(graduationResult);
+
+		mockMvc.perform(
+				post("/api/v1/graduations/check")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(request))
+			)
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.user.studentNumber").value("60190872"))
+			.andExpect(jsonPath("$.user.totalCredit").value(128))
+			.andExpect(jsonPath("$.user.takenCredit").value(133))
+			.andExpect(jsonPath("$.user.graduated").value(true));
+	}
+}

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/user/api/finduserinformation/dto/response/UserInformationResponseTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/user/api/finduserinformation/dto/response/UserInformationResponseTest.java
@@ -1,0 +1,41 @@
+package com.plzgraduate.myongjigraduatebe.user.api.finduserinformation.dto.response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationResult;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class UserInformationResponseTest {
+
+	@DisplayName("졸업진단 응답의 사용자 정보는 계산된 졸업 결과를 반영한다.")
+	@Test
+	void ofBuildsResponseFromGraduationResult() {
+		User user = User.builder()
+			.authId("anonymous")
+			.name("방현우")
+			.studentNumber("60190872")
+			.primaryMajor("국제통상학과")
+			.dualMajor("경영정보학과")
+			.totalCredit(0)
+			.takenCredit(0)
+			.graduated(false)
+			.build();
+
+		GraduationResult graduationResult = GraduationResult.builder()
+			.totalCredit(128)
+			.takenCredit(133)
+			.graduated(true)
+			.build();
+
+		UserInformationResponse response = UserInformationResponse.of(user, graduationResult);
+
+		assertThat(response.getStudentNumber()).isEqualTo("60190872");
+		assertThat(response.getStudentName()).isEqualTo("방현우");
+		assertThat(response.getTotalCredit()).isEqualTo(128);
+		assertThat(response.getTakenCredit()).isEqualTo(133);
+		assertThat(response.isGraduated()).isTrue();
+		assertThat(response.getCompleteDivision()).hasSize(2);
+	}
+}

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/user/api/finduserinformation/dto/response/UserInformationResponseTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/user/api/finduserinformation/dto/response/UserInformationResponseTest.java
@@ -38,4 +38,34 @@ class UserInformationResponseTest {
 		assertThat(response.isGraduated()).isTrue();
 		assertThat(response.getCompleteDivision()).hasSize(2);
 	}
+
+	@DisplayName("부전공이 있으면 completeDivision에 SUB가 포함된다.")
+	@Test
+	void ofIncludesSubMajorInCompleteDivision() {
+		User user = User.builder()
+			.authId("anonymous")
+			.name("홍길동")
+			.studentNumber("60202000")
+			.primaryMajor("경영학과")
+			.subMajor("경제학과")
+			.totalCredit(0)
+			.takenCredit(0)
+			.graduated(false)
+			.build();
+
+		GraduationResult graduationResult = GraduationResult.builder()
+			.totalCredit(120)
+			.takenCredit(120)
+			.graduated(true)
+			.build();
+
+		UserInformationResponse response = UserInformationResponse.of(user, graduationResult);
+
+		assertThat(response.getCompleteDivision())
+			.extracting(CompleteDivisionResponse::getMajorType, CompleteDivisionResponse::getMajor)
+			.contains(
+				org.assertj.core.groups.Tuple.tuple("PRIMARY", "경영학과"),
+				org.assertj.core.groups.Tuple.tuple("SUB", "경제학과")
+			);
+	}
 }


### PR DESCRIPTION
## Issue
졸업 가능임에도 졸업 불가로 나오는 문제

## ✅ 작업 내용
- 비회원 졸업검사 응답의 user 값이 graduationResult와 다르게 내려가던 문제 수정
- 응답의 user 학점/졸업 여부가 계산 결과와 일치하도록 수정
