### PR TITLE
[DEV-104] 기존 파싱 실패 재분석 dry-run API 추가

### DIFF
--- a/src/main/java/com/plzgraduate/myongjigraduatebe/core/config/SecurityConfig.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/core/config/SecurityConfig.java
@@ -62,6 +62,7 @@ public class SecurityConfig {
 	                API_V1_PREFIX + "/lectures-info",         // 강좌 정보 조회
 	                API_V1_PREFIX + "/lecture-reviews",       // 강좌평 조회
 	                API_V1_PREFIX + "/parsing-text/analyze-existing-failures", // 기존 실패 데이터 재분석
+	                API_V1_PREFIX + "/parsing-text/analyze-existing-failures/dry-run", // 기존 실패 데이터 재분석 미리보기
 	                "/v3/api-docs/**",
 	                "/swagger-ui/**",
 	                "/swagger-ui.html",

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/api/ParsingTextController.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/api/ParsingTextController.java
@@ -8,6 +8,7 @@ import com.plzgraduate.myongjigraduatebe.core.meta.LoginUser;
 import com.plzgraduate.myongjigraduatebe.core.meta.WebAdapter;
 import com.plzgraduate.myongjigraduatebe.parsing.api.dto.request.ParsingTextRequest;
 import com.plzgraduate.myongjigraduatebe.parsing.api.dto.response.AnalyzeExistingFailuresResponse;
+import com.plzgraduate.myongjigraduatebe.parsing.api.dto.response.AnalyzeExistingFailuresDryRunResponse;
 import com.plzgraduate.myongjigraduatebe.parsing.application.service.FailureAnalysisService;
 import com.plzgraduate.myongjigraduatebe.parsing.application.usecase.ParsingTextHistoryUseCase;
 import com.plzgraduate.myongjigraduatebe.parsing.application.usecase.ParsingTextUseCase;
@@ -66,6 +67,19 @@ public class ParsingTextController implements ParsingTextApiPresentation {
 		validateAdminApiKey(apiKey);
 		int analyzedCount = failureAnalysisService.analyzeExistingFailures();
 		return AnalyzeExistingFailuresResponse.of(analyzedCount);
+	}
+
+	/**
+	 * 기존 실패 데이터를 변경하지 않고 현재 데이터 기준으로 재분석합니다.
+	 * 개인정보와 개별 실패 상세는 반환하지 않고 집계만 제공합니다.
+	 */
+	@PostMapping("/analyze-existing-failures/dry-run")
+	public AnalyzeExistingFailuresDryRunResponse previewExistingFailures(
+		@RequestHeader(value = "X-Admin-Key", required = false) String apiKey
+	) {
+		validateAdminApiKey(apiKey);
+		return AnalyzeExistingFailuresDryRunResponse.from(
+			failureAnalysisService.previewExistingFailures());
 	}
 
 	private void validateAdminApiKey(String apiKey) {

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/api/dto/response/AnalyzeExistingFailuresDryRunResponse.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/api/dto/response/AnalyzeExistingFailuresDryRunResponse.java
@@ -1,0 +1,24 @@
+package com.plzgraduate.myongjigraduatebe.parsing.api.dto.response;
+
+import com.plzgraduate.myongjigraduatebe.parsing.application.service.FailureAnalysisService.FailureAnalysisPreview;
+import com.plzgraduate.myongjigraduatebe.parsing.domain.FailureReason;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class AnalyzeExistingFailuresDryRunResponse {
+
+	private final int totalCount;
+	private final int passedCount;
+	private final Map<FailureReason, Integer> failureCounts;
+
+	private AnalyzeExistingFailuresDryRunResponse(FailureAnalysisPreview preview) {
+		this.totalCount = preview.getTotalCount();
+		this.passedCount = preview.getPassedCount();
+		this.failureCounts = preview.getFailureCounts();
+	}
+
+	public static AnalyzeExistingFailuresDryRunResponse from(FailureAnalysisPreview preview) {
+		return new AnalyzeExistingFailuresDryRunResponse(preview);
+	}
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/application/service/FailureAnalysisService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/application/service/FailureAnalysisService.java
@@ -19,12 +19,15 @@ import com.plzgraduate.myongjigraduatebe.parsing.domain.ParsingInformation;
 import com.plzgraduate.myongjigraduatebe.parsing.domain.ParsingTextHistory;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.EnglishLevel;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.KoreanLevel;
+import java.util.EnumMap;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
 
@@ -35,6 +38,7 @@ public class FailureAnalysisService {
 
 	private static final String GRADUATION_CHECK_ERROR_PREFIX = "졸업 검사 중 오류 발생: ";
 	private static final int BATCH_SIZE = 100;
+	private static final String REANALYSIS_PASSED_DETAILS = "현재 데이터와 졸업요건으로 재분석을 통과했습니다.";
 
 	private final ParsingAnonymousUseCase parsingAnonymousUseCase;
 	private final CheckGraduationRequirementUseCase checkGraduationRequirementUseCase;
@@ -150,10 +154,44 @@ public class FailureAnalysisService {
 			return new FailureAnalysisResult(FailureReason.GRADUATION_CHECK_FAILED, GRADUATION_CHECK_ERROR_PREFIX + e.getMessage());
 		}
 
-		return new FailureAnalysisResult(
-			FailureReason.UNKNOWN_ERROR,
-			"모든 검증 단계를 통과했지만 실패로 기록되었습니다."
-		);
+		return FailureAnalysisResult.passed();
+	}
+
+	/**
+	 * failureReason이 없는 기존 실패 이력을 변경 없이 재분석한다.
+	 * 개인정보가 포함된 parsingText와 failureDetails는 결과에 포함하지 않는다.
+	 */
+	public FailureAnalysisPreview previewExistingFailures() {
+		int page = 0;
+		int totalCount = 0;
+		int passedCount = 0;
+		Map<FailureReason, Integer> failureCounts = new EnumMap<>(FailureReason.class);
+
+		while (true) {
+			List<ParsingTextHistory> batch = queryParsingTextHistoryPort
+				.findByParsingResultAndFailureReasonIsNull(
+					PageRequest.of(page, BATCH_SIZE, Sort.by(Sort.Direction.ASC, "id")));
+			if (batch.isEmpty()) {
+				break;
+			}
+
+			for (ParsingTextHistory history : batch) {
+				FailureAnalysisResult result = analyzeFailure(
+					history.getParsingText(),
+					history.getUser().getEnglishLevel(),
+					history.getUser().getKoreanLevel()
+				);
+				totalCount++;
+				if (result.isPassed()) {
+					passedCount++;
+				} else {
+					failureCounts.merge(result.getFailureReason(), 1, Integer::sum);
+				}
+			}
+			page++;
+		}
+
+		return new FailureAnalysisPreview(totalCount, passedCount, failureCounts);
 	}
 
 	private FailureAnalysisResult classifyGraduationIllegalArgument(IllegalArgumentException e) {
@@ -249,10 +287,53 @@ public class FailureAnalysisService {
 	public static class FailureAnalysisResult {
 		private final FailureReason failureReason;
 		private final String failureDetails;
+		private final boolean passed;
 
 		public FailureAnalysisResult(FailureReason failureReason, String failureDetails) {
+			this(failureReason, failureDetails, false);
+		}
+
+		private FailureAnalysisResult(
+			FailureReason failureReason,
+			String failureDetails,
+			boolean passed
+		) {
 			this.failureReason = failureReason;
 			this.failureDetails = failureDetails;
+			this.passed = passed;
+		}
+
+		private static FailureAnalysisResult passed() {
+			return new FailureAnalysisResult(
+				FailureReason.RESOLVED,
+				REANALYSIS_PASSED_DETAILS,
+				true
+			);
+		}
+	}
+
+	@Getter
+	public static class FailureAnalysisPreview {
+		private final int totalCount;
+		private final int passedCount;
+		private final Map<FailureReason, Integer> failureCounts;
+
+		private FailureAnalysisPreview(
+			int totalCount,
+			int passedCount,
+			Map<FailureReason, Integer> failureCounts
+		) {
+			this.totalCount = totalCount;
+			this.passedCount = passedCount;
+			this.failureCounts = Map.copyOf(failureCounts);
+		}
+
+		public static FailureAnalysisPreview of(
+			int totalCount,
+			int passedCount,
+			Map<FailureReason, Integer> failureCounts
+		) {
+			return new FailureAnalysisPreview(totalCount, passedCount, failureCounts);
 		}
 	}
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/domain/FailureReason.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/domain/FailureReason.java
@@ -14,6 +14,7 @@ public enum FailureReason {
 	GRADUATION_REQUIREMENT_NOT_FOUND("졸업 요건을 찾을 수 없습니다.", "전공명/입학년도 조합에 맞는 졸업 요건을 찾을 수 없습니다."),
 	COLLEGE_NOT_FOUND("단과대를 찾을 수 없습니다.", "소속 단과대 정보를 시스템에서 찾을 수 없습니다."),
 	LECTURE_NOT_FOUND("과목 정보를 찾을 수 없습니다.", "성적표에 포함된 과목 정보를 시스템에서 찾을 수 없습니다."),
+	RESOLVED("재분석을 통과했습니다.", "현재 데이터와 졸업요건으로 기존 실패가 해소되었습니다."),
 	UNKNOWN_ERROR("알 수 없는 오류가 발생했습니다.", "예상치 못한 오류가 발생했습니다.");
 
 	private final String message;
@@ -24,4 +25,3 @@ public enum FailureReason {
 		this.description = description;
 	}
 }
-

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/parsing/api/ParsingTextControllerTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/parsing/api/ParsingTextControllerTest.java
@@ -12,8 +12,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.plzgraduate.myongjigraduatebe.core.exception.InvalidPdfException;
 import com.plzgraduate.myongjigraduatebe.parsing.api.dto.request.ParsingTextRequest;
+import com.plzgraduate.myongjigraduatebe.parsing.application.service.FailureAnalysisService.FailureAnalysisPreview;
+import com.plzgraduate.myongjigraduatebe.parsing.domain.FailureReason;
 import com.plzgraduate.myongjigraduatebe.support.WebAdaptorTestSupport;
 import com.plzgraduate.myongjigraduatebe.support.WithMockAuthenticationUser;
+import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -134,6 +137,41 @@ class ParsingTextControllerTest extends WebAdaptorTestSupport {
 
 		//then
 		actions
+			.andDo(print())
+			.andExpect(status().isUnauthorized());
+	}
+
+	@DisplayName("올바른 API Key로 기존 실패 데이터 dry-run 결과를 조회한다.")
+	@Test
+	void previewExistingFailuresWithValidApiKey() throws Exception {
+		//given
+		FailureAnalysisPreview preview = FailureAnalysisPreview.of(
+			5, 3, Map.of(FailureReason.LECTURE_NOT_FOUND, 2));
+		given(failureAnalysisService.previewExistingFailures()).willReturn(preview);
+
+		//when
+		ResultActions actions = mockMvc.perform(
+			post("/api/v1/parsing-text/analyze-existing-failures/dry-run")
+				.header("X-Admin-Key", "test-admin-key")
+				.with(csrf())
+		);
+
+		//then
+		actions
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.totalCount").value(5))
+			.andExpect(jsonPath("$.passedCount").value(3))
+			.andExpect(jsonPath("$.failureCounts.LECTURE_NOT_FOUND").value(2));
+	}
+
+	@DisplayName("API Key가 없으면 기존 실패 데이터 dry-run 요청이 401로 실패한다.")
+	@Test
+	void previewExistingFailuresWithoutApiKey() throws Exception {
+		mockMvc.perform(
+			post("/api/v1/parsing-text/analyze-existing-failures/dry-run")
+				.with(csrf())
+		)
 			.andDo(print())
 			.andExpect(status().isUnauthorized());
 	}

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/parsing/application/service/FailureAnalysisServiceTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/parsing/application/service/FailureAnalysisServiceTest.java
@@ -29,6 +29,7 @@ import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -37,6 +38,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.transaction.PlatformTransactionManager;
 
 @ExtendWith(MockitoExtension.class)
@@ -342,7 +344,7 @@ class FailureAnalysisServiceTest {
 		assertThat(result.getFailureDetails()).contains("졸업 검사 중 오류 발생");
 	}
 
-	@DisplayName("모든 검증 단계를 통과하면 UNKNOWN_ERROR를 반환한다")
+	@DisplayName("모든 검증 단계를 통과하면 재분석 통과 상태를 반환한다")
 	@Test
 	void analyzeFailure_allStepsPassed() {
 		//given
@@ -357,8 +359,51 @@ class FailureAnalysisServiceTest {
 		FailureAnalysisService.FailureAnalysisResult result = failureAnalysisService.analyzeFailure(VALID_PARSING_TEXT);
 
 		//then
-		assertThat(result.getFailureReason()).isEqualTo(FailureReason.UNKNOWN_ERROR);
-		assertThat(result.getFailureDetails()).contains("모든 검증 단계를 통과했지만 실패로 기록되었습니다");
+		assertThat(result.getFailureReason()).isEqualTo(FailureReason.RESOLVED);
+		assertThat(result.isPassed()).isTrue();
+		assertThat(result.getFailureDetails()).contains("재분석을 통과했습니다");
+	}
+
+	@DisplayName("기존 실패 데이터 dry-run은 이력을 저장하지 않고 결과를 집계한다")
+	@Test
+	void previewExistingFailures() {
+		//given
+		User user = createUser();
+		ParsingTextHistory passedHistory = ParsingTextHistory.builder()
+			.id(1L)
+			.user(user)
+			.parsingText(VALID_PARSING_TEXT)
+			.parsingResult(ParsingResult.FAIL)
+			.build();
+		ParsingTextHistory failedHistory = ParsingTextHistory.builder()
+			.id(2L)
+			.user(user)
+			.parsingText("잘못된 텍스트")
+			.parsingResult(ParsingResult.FAIL)
+			.build();
+		PageRequest firstPage = PageRequest.of(0, 100, Sort.by(Sort.Direction.ASC, "id"));
+		PageRequest secondPage = PageRequest.of(1, 100, Sort.by(Sort.Direction.ASC, "id"));
+
+		given(queryParsingTextHistoryPort.findByParsingResultAndFailureReasonIsNull(firstPage))
+			.willReturn(List.of(passedHistory, failedHistory));
+		given(queryParsingTextHistoryPort.findByParsingResultAndFailureReasonIsNull(secondPage))
+			.willReturn(Collections.emptyList());
+		User anonymous = createAnonymousUser();
+		TakenLectureInventory inventory = TakenLectureInventory.from(new HashSet<>());
+		given(parsingAnonymousUseCase.parseAnonymous(
+			eq(user.getEnglishLevel()), eq(user.getKoreanLevel()), eq(VALID_PARSING_TEXT)))
+			.willReturn(new ParsingAnonymousDto(anonymous, inventory));
+
+		//when
+		FailureAnalysisService.FailureAnalysisPreview preview =
+			failureAnalysisService.previewExistingFailures();
+
+		//then
+		assertThat(preview.getTotalCount()).isEqualTo(2);
+		assertThat(preview.getPassedCount()).isEqualTo(1);
+		assertThat(preview.getFailureCounts()).isEqualTo(
+			Map.of(FailureReason.PARSING_EXCEPTION, 1));
+		then(saveParsingTextHistoryPort).shouldHaveNoInteractions();
 	}
 
 	@DisplayName("기존 실패 데이터 재분석 - 개별 분석 중 오류 발생 시 건너뛰고 계속한다")


### PR DESCRIPTION
## Issue

- DEV-104

## ✅ 작업 내용

- 기존 실패 이력을 DB 변경 없이 재분석할 수 있도록 `POST /api/v1/parsing-text/analyze-existing-failures/dry-run` 관리자 API를 추가했습니다.
- dry-run 응답은 전체 분석 건수, 재분석 통과 건수, 실패 원인별 건수만 제공합니다. 성적표 파싱 원문과 개별 실패 상세 등 개인정보가 포함될 수 있는 값은 응답하지 않습니다.
- 기존 실제 반영 API와 dry-run이 동일한 실패 분석 로직을 사용하도록 구성해, 사전 확인 결과와 실제 반영 결과의 분류 기준이 달라지지 않게 했습니다.
- 재분석을 정상 통과한 이력은 더 이상 `UNKNOWN_ERROR`로 분류하지 않고 `RESOLVED`로 저장하도록 변경했습니다.
- dry-run 경로를 Spring Security 허용 목록에 추가하되, 기존 관리자 API와 동일하게 컨트롤러에서 `X-Admin-Key`를 검증하도록 유지했습니다.
- dry-run 집계, DB 미변경, 관리자 키 검증, 정상 재분석의 `RESOLVED` 처리를 검증하는 테스트를 추가했습니다.

### DB 반영

- 스키마 및 마이그레이션 변경은 없습니다.
- dry-run API는 `parsing_text_history`를 조회만 하며 `failure_reason`, `failure_details`를 갱신하지 않습니다.
- 실제 반영 API는 기존과 같이 실패 이력을 갱신하지만, 정상 통과 결과는 `RESOLVED`와 재분석 통과 상세를 저장합니다.
- 로컬 DB에서 dry-run만 실행했으며 실제 반영 API는 호출하지 않았습니다.

### 검증

- `./gradlew test` 전체 테스트 통과
- Swagger에서 로컬 관리자 키로 dry-run API 호출 확인
- 로컬 미분류 실패 이력 504건 재분석 결과 확인
  - 재분석 통과 예상: 209건
  - `MAJOR_NAME_MISMATCH`: 140건
  - `PARSING_EXCEPTION`: 105건
  - `EMPTY_PARSING_TEXT`: 50건
- `git diff --cached --check` 통과

## 🤔 고민 했던 부분

- 기존 실패 이력을 바로 갱신하면 최신 강의·정책 데이터가 실제로 얼마나 문제를 해소했는지 사전에 확인하기 어렵습니다. 같은 분석 로직을 사용하는 비변경 dry-run을 먼저 제공해 운영자가 영향 범위를 확인한 뒤 실제 반영 여부를 결정할 수 있게 했습니다.
- 실패 이력에는 성적표 원문과 사용자 정보가 포함될 수 있어, dry-run은 개별 결과나 예외 메시지 대신 원인별 집계만 반환하도록 제한했습니다.
- 재분석 성공을 `UNKNOWN_ERROR`로 저장하면 성공과 알 수 없는 실패를 구분할 수 없으므로, 성공 상태를 명시하는 `RESOLVED`를 추가했습니다.
- `EMPTY_PARSING_TEXT`, `PARSING_EXCEPTION`, `MAJOR_NAME_MISMATCH`의 근본 원인 수정은 재분석 기능의 범위를 벗어나므로 후속 작업으로 분리했습니다.
