### PR TITLE
[DEV-105] 동일과목 코드를 반영한 핵심교양 판정 보정

### DIFF
--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/coreculture/CoreCultureDetailCategoryManager.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/coreculture/CoreCultureDetailCategoryManager.java
@@ -10,8 +10,11 @@ import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLecture;
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.StudentCategory;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
+import java.util.Comparator;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
@@ -24,10 +27,10 @@ public class CoreCultureDetailCategoryManager {
 		"데이터테크놀로지",
 		"디지털콘텐츠디자인"
 	);
-	private static final Lecture 과학과기술_예외_과목 = Lecture.from("KMA02136");
-	private static final Set<Lecture> 문화와예술_예외_과목 = Set.of(
-		Lecture.from("KMA02155"),
-		Lecture.from("KMA02156")
+	private static final String 과학과기술_예외_과목_인정코드 = "KMA02136";
+	private static final Set<String> 문화와예술_예외_과목_인정코드 = Set.of(
+		"KMA02155",
+		"KMA02156"
 	);
 
 	public DetailCategoryResult generate(
@@ -42,22 +45,39 @@ public class CoreCultureDetailCategoryManager {
 			graduationLectures,
 			category
 		);
-		Set<TakenLecture> finishedTakenLecture = new HashSet<>();
-		Set<Lecture> taken = new HashSet<>();
-		takenLectureInventory.getTakenLectures()
+		Set<String> graduationRecognitionCodes = graduationCoreCultureLectures.stream()
+			.map(Lecture::getRecognitionCode)
+			.collect(Collectors.toSet());
+		List<TakenLecture> matchedTakenLectures = takenLectureInventory.getTakenLectures()
 			.stream()
-			.filter(
-				takenLecture -> graduationCoreCultureLectures.contains(takenLecture.getLecture()))
-			.forEach(takenLecture -> {
-				finishedTakenLecture.add(takenLecture);
-				taken.add(takenLecture.getLecture());
-			});
-		takenLectureInventory.handleFinishedTakenLectures(finishedTakenLecture);
+			.filter(takenLecture -> graduationRecognitionCodes.contains(
+				takenLecture.getLecture().getRecognitionCode()))
+			.sorted(Comparator
+				.comparing(TakenLecture::getYear,
+					Comparator.nullsLast(Comparator.reverseOrder()))
+				.thenComparing(TakenLecture::getSemester,
+					Comparator.nullsLast(Comparator.reverseOrder()))
+				.thenComparing(takenLecture -> takenLecture.getLecture().getId(),
+					Comparator.reverseOrder()))
+			.collect(Collectors.toList());
+		Map<String, TakenLecture> latestTakenLectureByRecognitionCode = new LinkedHashMap<>();
+		matchedTakenLectures.forEach(
+			takenLecture -> latestTakenLectureByRecognitionCode.putIfAbsent(
+				takenLecture.getLecture().getRecognitionCode(), takenLecture));
+		Set<TakenLecture> recognizedTakenLectures = new HashSet<>(
+			latestTakenLectureByRecognitionCode.values());
+		Set<Lecture> taken = recognizedTakenLectures.stream()
+			.map(TakenLecture::getLecture)
+			.collect(Collectors.toSet());
+		graduationCoreCultureLectures.removeIf(lecture ->
+			latestTakenLectureByRecognitionCode.containsKey(lecture.getRecognitionCode()));
+		takenLectureInventory.handleFinishedTakenLectures(new HashSet<>(matchedTakenLectures));
 
 		DetailCategoryResult commonCultureDetailCategoryResult = DetailCategoryResult.create(
 			category.getName(), true, category.getTotalCredit());
 		calculateFreeElectiveLeftCredit(user, taken, commonCultureDetailCategoryResult);
-		calculateNormalLeftCredit(taken, finishedTakenLecture, commonCultureDetailCategoryResult);
+		calculateNormalLeftCredit(taken, recognizedTakenLectures,
+			commonCultureDetailCategoryResult);
 		commonCultureDetailCategoryResult.calculate(taken, graduationCoreCultureLectures);
 
 		return commonCultureDetailCategoryResult;
@@ -77,8 +97,8 @@ public class CoreCultureDetailCategoryManager {
 		User user, Set<Lecture> taken,
 		DetailCategoryResult commonCultureDetailCategoryResult
 	) {
-		if (ICT_DEPARTMENTS.contains(user.getPrimaryMajor()) && (taken.contains(과학과기술_예외_과목))) {
-			taken.remove(과학과기술_예외_과목);
+		if (ICT_DEPARTMENTS.contains(user.getPrimaryMajor()) && taken.removeIf(
+			lecture -> lecture.getRecognitionCode().equals(과학과기술_예외_과목_인정코드))) {
 			int exceptionLectureCredit = 3;
 			commonCultureDetailCategoryResult.addFreeElectiveLeftCredit(exceptionLectureCredit);
 		}
@@ -90,7 +110,8 @@ public class CoreCultureDetailCategoryManager {
 		DetailCategoryResult commonCultureDetailCategoryResult
 	) {
 		List<TakenLecture> cultureAndArtExceptionLectures = finishedTakenLecture.stream()
-			.filter(takenLecture -> 문화와예술_예외_과목.contains(takenLecture.getLecture())
+			.filter(takenLecture -> 문화와예술_예외_과목_인정코드.contains(
+				takenLecture.getLecture().getRecognitionCode())
 				&& takenLecture.getYear() == 2022
 				&& takenLecture.getSemester() == FIRST)
 			.collect(Collectors.toList());

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/lecture/domain/model/Lecture.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/lecture/domain/model/Lecture.java
@@ -74,6 +74,13 @@ public class Lecture implements Serializable {
 		return id.startsWith(CULTURE_CODE_START_PREFIX);
 	}
 
+	public String getRecognitionCode() {
+		if (duplicateCode == null || duplicateCode.isBlank()) {
+			return id;
+		}
+		return duplicateCode;
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) {

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/coreculture/CoreCultureDetailCategoryManagerTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/coreculture/CoreCultureDetailCategoryManagerTest.java
@@ -233,4 +233,77 @@ class CoreCultureDetailCategoryManagerTest {
 			)
 			.contains(coreCultureCategory.getName(), false, categoryTotalCredit, 6, 0);
 	}
+
+	@DisplayName("핵심교양 대표 코드와 다른 동일과목 코드로 수강해도 핵심교양으로 인정한다.")
+	@Test
+	void recognizeEquivalentLectureByDuplicateCode() {
+		User user = UserFixture.경영학과_19학번_ENG34();
+		Lecture representative = Lecture.of(
+			"KMA02155", "4차산업혁명시대의예술", 3, 0, "KMA02155");
+		Lecture equivalent = Lecture.of(
+			"KMC02234", "4차산업혁명시대의예술", 3, 0, "KMA02155");
+		TakenLecture equivalentTakenLecture = TakenLecture.of(
+			user, equivalent, 2023, Semester.FIRST);
+		TakenLectureInventory inventory = TakenLectureInventory.from(
+			Set.of(equivalentTakenLecture));
+
+		DetailCategoryResult result = manager.generate(
+			user,
+			inventory,
+			Set.of(CoreCulture.of(representative, CULTURE_ART)),
+			CULTURE_ART
+		);
+
+		assertThat(result.isCompleted()).isTrue();
+		assertThat(result.getTakenCredits()).isEqualTo(3);
+		assertThat(result.getTakenLectures()).containsExactly(equivalent);
+		assertThat(inventory.getTakenLectures()).isEmpty();
+	}
+
+	@DisplayName("같은 동일과목 그룹을 여러 번 수강하면 가장 최근 수강 한 건만 핵심교양으로 인정한다.")
+	@Test
+	void recognizeLatestLectureOnlyWithinDuplicateGroup() {
+		User user = UserFixture.경영학과_19학번_ENG34();
+		Lecture representative = Lecture.of(
+			"KMA02155", "4차산업혁명시대의예술", 3, 1, "KMA02155");
+		Lecture equivalent = Lecture.of(
+			"KMC02234", "4차산업혁명시대의예술", 3, 0, "KMA02155");
+		TakenLecture earliest = TakenLecture.of(user, representative, 2022, Semester.SECOND);
+		TakenLecture later = TakenLecture.of(user, equivalent, 2023, Semester.FIRST);
+		TakenLectureInventory inventory = TakenLectureInventory.from(Set.of(earliest, later));
+
+		DetailCategoryResult result = manager.generate(
+			user,
+			inventory,
+			Set.of(CoreCulture.of(representative, CULTURE_ART)),
+			CULTURE_ART
+		);
+
+		assertThat(result.getTakenCredits()).isEqualTo(3);
+		assertThat(result.getTakenLectures()).containsExactly(equivalent);
+		assertThat(inventory.getTakenLectures()).isEmpty();
+	}
+
+	@DisplayName("2022년 1학기에 수강한 동일과목 코드도 핵심교양이 아닌 일반교양으로 처리한다.")
+	@Test
+	void applyCultureArtExceptionByDuplicateCode() {
+		User user = UserFixture.경영학과_19학번_ENG34();
+		Lecture representative = Lecture.of(
+			"KMA02155", "4차산업혁명시대의예술", 3, 0, "KMA02155");
+		Lecture equivalent = Lecture.of(
+			"KMC02234", "4차산업혁명시대의예술", 3, 0, "KMA02155");
+		TakenLectureInventory inventory = TakenLectureInventory.from(Set.of(
+			TakenLecture.of(user, equivalent, 2022, Semester.FIRST)));
+
+		DetailCategoryResult result = manager.generate(
+			user,
+			inventory,
+			Set.of(CoreCulture.of(representative, CULTURE_ART)),
+			CULTURE_ART
+		);
+
+		assertThat(result.isCompleted()).isFalse();
+		assertThat(result.getTakenCredits()).isZero();
+		assertThat(result.getNormalLeftCredit()).isEqualTo(3);
+	}
 }

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/lecture/domain/model/LectureTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/lecture/domain/model/LectureTest.java
@@ -35,4 +35,20 @@ class LectureTest {
 		assertThat(isCulture).isFalse();
 	}
 
+	@DisplayName("동일과목 대표 코드가 있으면 대표 코드를 인정 코드로 사용한다.")
+	@Test
+	void getRecognitionCodeWithDuplicateCode() {
+		Lecture lecture = Lecture.of("KMC02234", "4차산업혁명시대의예술", 3, 0, "KMA02155");
+
+		assertThat(lecture.getRecognitionCode()).isEqualTo("KMA02155");
+	}
+
+	@DisplayName("동일과목 대표 코드가 없으면 과목 코드를 인정 코드로 사용한다.")
+	@Test
+	void getRecognitionCodeWithoutDuplicateCode() {
+		Lecture lecture = Lecture.of("KMA02155", "4차산업혁명시대의예술", 3, 0, null);
+
+		assertThat(lecture.getRecognitionCode()).isEqualTo("KMA02155");
+	}
+
 }


### PR DESCRIPTION
## Issue

- DEV-105

## ✅ 작업 내용

- `duplicate_code`가 존재하면 동일과목 인정 코드로 사용하고, 없으면 기존 과목 코드를 사용하도록 했습니다.
- 핵심교양 대표 과목과 다른 동일과목 코드로 수강한 경우에도 핵심교양으로 인정하도록 보정했습니다.
- 동일과목 그룹의 수강 이력이 여러 건이면 가장 최근 수강만 핵심교양 학점으로 인정하고, 이전 수강은 다른 영역의 학점으로 중복 계산되지 않도록 처리했습니다.
- 2022년 1학기 문화와예술 예외와 ICT 계열 과학과기술 예외에도 동일과목 인정 코드를 적용했습니다.
- Flyway 및 DB 스키마 변경은 포함하지 않았습니다.

### 검증

- `./gradlew test --tests '*LectureTest' --tests '*CoreCultureDetailCategoryManagerTest' --tests '*CoreCultureGraduationManagerTest' --tests '*CalculateCoreCultureGraduationServiceTest'`\n- 대표 코드와 다른 동일과목 코드의 핵심교양 인정 테스트\n- 동일과목 그룹에서 최신 수강만 인정하는 테스트\n- 동일과목 코드에도 2022년 1학기 예외가 적용되는 테스트\n\n## 🤔 고민 했던 부분\n\n- 명지대학교 학사 안내상 동일과목을 재수강하면 이전 성적은 `R` 처리되어 취득학점에 포함되지 않으므로, 동일 그룹이 여러 건 전달되는 방어 상황에서도 최신 수강만 인정하도록 했습니다.\n- 공통교양·학문기초·전공·부전공에도 실제 과목 ID 비교가 남아 있지만 정상 성적표에서는 이전 재수강 과목이 `R`로 제외됩니다. 이번 PR의 영향 범위를 핵심교양으로 제한하고, 전 영역 공통 정규화는 저우선순위 후속 작업으로 분리했습니다.\n- 기간 조건을 데이터로 관리하려면 별도 스키마 설계가 필요하지만, 이번 작업에서는 요청에 따라 Flyway 마이그레이션과 스키마 변경을 하지 않았습니다.