### PR TITLE
[DEV-109] 비회원 졸업검사 이력 추적

### DIFF
--- a/docs/database/tables/parsing_text_history.md
+++ b/docs/database/tables/parsing_text_history.md
@@ -1,0 +1,22 @@
+# parsing_text_history
+
+- Entity: `ParsingTextHistoryJpaEntity`
+- 설명: 성적표 파싱 텍스트와 파싱 결과 이력
+- 공통 컬럼: `TimeBaseEntity` 상속으로 `created_at`, `updated_at` 포함
+
+| 컬럼 | Java 타입 | DB 타입 추정 | 제약/관계 | 비고 |
+| --- | --- | --- | --- | --- |
+| `id` | `Long` | `BIGINT` | PK, auto increment | 내부 식별자 |
+| `user_id` | `UserJpaEntity` | `BIGINT` | nullable, FK -> `user.id` | 회원 요청만 연결하며 비회원 요청은 `NULL` |
+| `parsing_text` | `String` | `VARCHAR(5000)` |  | `@Column(length = 5000)` |
+| `parsing_result` | `ParsingResult` | `VARCHAR` |  | `EnumType.STRING` |
+| `failure_reason` | `FailureReason` | `VARCHAR(100)` |  | `EnumType.STRING`, Flyway V1에서 추가 |
+| `failure_details` | `String` | `TEXT` |  | 실패 상세 정보, Flyway V1에서 추가 |
+| `tracking_code` | `String` | `VARCHAR(36)` | nullable, unique | 비회원 검사 건별 문의용 UUID, Flyway V8에서 추가 |
+| `requester_type` | `ParsingRequesterType` | `VARCHAR(20)` | not null | `MEMBER` 또는 `ANONYMOUS`, Flyway V8에서 추가 |
+| `created_at` | `Instant` | `TIMESTAMP` | not null, updatable false | 생성 시각 |
+| `updated_at` | `Instant` | `TIMESTAMP` | not null | 수정 시각 |
+
+비회원 졸업검사는 성공과 실패를 모두 저장한다. 성공 이력은 이용량과 성공률 집계에,
+실패 이력은 오류 분석과 사용자 문의 대응에 사용한다. 회원 이력과 달리 `user_id`는
+`NULL`이며, API 응답의 `tracking_code`로 개별 요청을 찾는다.

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/core/exception/AnonymousGraduationCheckException.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/core/exception/AnonymousGraduationCheckException.java
@@ -1,0 +1,14 @@
+package com.plzgraduate.myongjigraduatebe.core.exception;
+
+import lombok.Getter;
+
+@Getter
+public class AnonymousGraduationCheckException extends RuntimeException {
+
+	private final String trackingCode;
+
+	public AnonymousGraduationCheckException(String trackingCode, Exception cause) {
+		super(cause.getMessage(), cause);
+		this.trackingCode = trackingCode;
+	}
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/core/exception/ExceptionResponse.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/core/exception/ExceptionResponse.java
@@ -1,17 +1,25 @@
 package com.plzgraduate.myongjigraduatebe.core.exception;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Getter;
 
 @Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ExceptionResponse {
 
 	private final String errorCode;
+	private final String trackingCode;
 
-	private ExceptionResponse(String errorCode) {
+	private ExceptionResponse(String errorCode, String trackingCode) {
 		this.errorCode = errorCode;
+		this.trackingCode = trackingCode;
 	}
 
 	public static ExceptionResponse from(String errorCode) {
-		return new ExceptionResponse(errorCode);
+		return new ExceptionResponse(errorCode, null);
+	}
+
+	public static ExceptionResponse tracked(String errorCode, String trackingCode) {
+		return new ExceptionResponse(errorCode, trackingCode);
 	}
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/core/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/core/exception/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.ObjectError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -21,6 +22,24 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+	@ExceptionHandler(AnonymousGraduationCheckException.class)
+	public ResponseEntity<ExceptionResponse> handleAnonymousGraduationCheckException(
+		AnonymousGraduationCheckException e
+	) {
+		Throwable cause = e.getCause();
+		boolean badRequest = cause instanceof IllegalArgumentException
+			|| cause instanceof IllegalStateException
+			|| cause instanceof PdfParsingException
+			|| cause instanceof InvalidPdfException;
+		HttpStatus status = badRequest ? HttpStatus.BAD_REQUEST : HttpStatus.INTERNAL_SERVER_ERROR;
+		String errorCode = badRequest
+			? cause.getMessage()
+			: ErrorCode.INTERNAL_SEVER_ERROR.toString();
+		log.warn("Anonymous graduation check failed. trackingCode={}", e.getTrackingCode(), cause);
+		return ResponseEntity.status(status)
+			.body(ExceptionResponse.tracked(errorCode, e.getTrackingCode()));
+	}
 
 	@ExceptionHandler({
 			IllegalArgumentException.class,

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/api/CheckGraduationRequirementController.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/api/CheckGraduationRequirementController.java
@@ -1,16 +1,21 @@
 package com.plzgraduate.myongjigraduatebe.graduation.api;
 
 import com.plzgraduate.myongjigraduatebe.core.meta.WebAdapter;
+import com.plzgraduate.myongjigraduatebe.core.exception.AnonymousGraduationCheckException;
 import com.plzgraduate.myongjigraduatebe.graduation.api.dto.request.CheckGraduationRequirementRequest;
 import com.plzgraduate.myongjigraduatebe.graduation.api.dto.response.CheckGraduationRequirementResponse;
 import com.plzgraduate.myongjigraduatebe.graduation.application.usecase.CheckGraduationRequirementUseCase;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationResult;
 import com.plzgraduate.myongjigraduatebe.parsing.application.usecase.ParsingAnonymousUseCase;
+import com.plzgraduate.myongjigraduatebe.parsing.application.usecase.ParsingTextHistoryUseCase;
 import com.plzgraduate.myongjigraduatebe.parsing.application.usecase.dto.ParsingAnonymousDto;
 import com.plzgraduate.myongjigraduatebe.user.api.finduserinformation.dto.response.UserInformationResponse;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.EnglishLevel;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.KoreanLevel;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,29 +23,72 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @WebAdapter
 @RequestMapping("/api/v1/graduations/check")
 @RequiredArgsConstructor
+@Slf4j
 public class CheckGraduationRequirementController implements CheckGraduationRequirementApiPresentation {
 
 	private final ParsingAnonymousUseCase parsingAnonymousUseCase;
 	private final CheckGraduationRequirementUseCase checkGraduationRequirementUseCase;
+	private final ParsingTextHistoryUseCase parsingTextHistoryUseCase;
 
 	@PostMapping
 	public CheckGraduationRequirementResponse checkGraduationRequirement(
 		@Valid @RequestBody CheckGraduationRequirementRequest checkGraduationRequirementRequest
 	) {
-		ParsingAnonymousDto parsingAnonymousDto = parsingAnonymousUseCase.parseAnonymous(
-			checkGraduationRequirementRequest.getEngLv(),
-			checkGraduationRequirementRequest.getKorLv(),
-			checkGraduationRequirementRequest.getParsingText()
-		);
-		User anonymous = parsingAnonymousDto.getAnonymous();
-		GraduationResult graduationResult = checkGraduationRequirementUseCase.checkGraduationRequirement(
-			anonymous,
-			parsingAnonymousDto.getTakenLectureInventory()
-		);
+		EnglishLevel englishLevel = EnglishLevel.ENG12;
+		KoreanLevel koreanLevel = KoreanLevel.KOR12;
+		String parsingText = checkGraduationRequirementRequest.getParsingText();
+		try {
+			englishLevel = checkGraduationRequirementRequest.getEngLv();
+			koreanLevel = checkGraduationRequirementRequest.getKorLv();
+			ParsingAnonymousDto parsingAnonymousDto = parsingAnonymousUseCase.parseAnonymous(
+				englishLevel,
+				koreanLevel,
+				parsingText
+			);
+			User anonymous = parsingAnonymousDto.getAnonymous();
+			GraduationResult graduationResult = checkGraduationRequirementUseCase.checkGraduationRequirement(
+				anonymous,
+				parsingAnonymousDto.getTakenLectureInventory()
+			);
+			String trackingCode = saveSuccessHistory(parsingText);
+			return new CheckGraduationRequirementResponse(
+				UserInformationResponse.of(anonymous, graduationResult),
+				graduationResult,
+				trackingCode
+			);
+		} catch (Exception exception) {
+			String trackingCode = saveFailureHistory(
+				parsingText,
+				englishLevel,
+				koreanLevel
+			);
+			throw new AnonymousGraduationCheckException(trackingCode, exception);
+		}
+	}
 
-		return new CheckGraduationRequirementResponse(
-			UserInformationResponse.of(anonymous, graduationResult),
-			graduationResult
-		);
+	private String saveSuccessHistory(String parsingText) {
+		try {
+			return parsingTextHistoryUseCase.generateAnonymousSucceedParsingTextHistory(parsingText);
+		} catch (Exception historyException) {
+			log.error("Failed to save anonymous success parsing history", historyException);
+			return null;
+		}
+	}
+
+	private String saveFailureHistory(
+		String parsingText,
+		EnglishLevel englishLevel,
+		KoreanLevel koreanLevel
+	) {
+		try {
+			return parsingTextHistoryUseCase.generateAnonymousFailedParsingTextHistory(
+				parsingText,
+				englishLevel,
+				koreanLevel
+			);
+		} catch (Exception historyException) {
+			log.error("Failed to save anonymous failure parsing history", historyException);
+			return null;
+		}
 	}
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/api/dto/response/CheckGraduationRequirementResponse.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/graduation/api/dto/response/CheckGraduationRequirementResponse.java
@@ -9,11 +9,15 @@ public class CheckGraduationRequirementResponse {
 
 	private final UserInformationResponse user;
 	private final GraduationResult graduationResult;
+	private final String trackingCode;
 
 	public CheckGraduationRequirementResponse(
-		UserInformationResponse user, GraduationResult graduationResult
+		UserInformationResponse user,
+		GraduationResult graduationResult,
+		String trackingCode
 	) {
 		this.user = user;
 		this.graduationResult = graduationResult;
+		this.trackingCode = trackingCode;
 	}
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/application/service/ParsingTextHistoryService.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/application/service/ParsingTextHistoryService.java
@@ -6,9 +6,13 @@ import com.plzgraduate.myongjigraduatebe.parsing.application.usecase.ParsingText
 import com.plzgraduate.myongjigraduatebe.parsing.domain.ParsingTextHistory;
 import com.plzgraduate.myongjigraduatebe.user.application.usecase.find.FindUserUseCase;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.User;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.EnglishLevel;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.KoreanLevel;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.annotation.Propagation;
 
 @Slf4j
 @UseCase
@@ -48,5 +52,36 @@ class ParsingTextHistoryService implements ParsingTextHistoryUseCase {
 				analysisResult.getFailureDetails()
 			)
 		);
+	}
+
+	@Override
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public String generateAnonymousSucceedParsingTextHistory(String parsingText) {
+		String trackingCode = UUID.randomUUID().toString();
+		saveParsingTextHistoryPort.saveParsingTextHistory(
+			ParsingTextHistory.anonymousSuccess(parsingText, trackingCode)
+		);
+		return trackingCode;
+	}
+
+	@Override
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public String generateAnonymousFailedParsingTextHistory(
+		String parsingText,
+		EnglishLevel englishLevel,
+		KoreanLevel koreanLevel
+	) {
+		String trackingCode = UUID.randomUUID().toString();
+		FailureAnalysisService.FailureAnalysisResult analysisResult =
+			failureAnalysisService.analyzeFailure(parsingText, englishLevel, koreanLevel);
+		saveParsingTextHistoryPort.saveParsingTextHistory(
+			ParsingTextHistory.anonymousFail(
+				parsingText,
+				analysisResult.getFailureReason(),
+				analysisResult.getFailureDetails(),
+				trackingCode
+			)
+		);
+		return trackingCode;
 	}
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/application/usecase/ParsingTextHistoryUseCase.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/application/usecase/ParsingTextHistoryUseCase.java
@@ -1,8 +1,19 @@
 package com.plzgraduate.myongjigraduatebe.parsing.application.usecase;
 
+import com.plzgraduate.myongjigraduatebe.user.domain.model.EnglishLevel;
+import com.plzgraduate.myongjigraduatebe.user.domain.model.KoreanLevel;
+
 public interface ParsingTextHistoryUseCase {
 
 	void generateSucceedParsingTextHistory(Long userId, String parsingText);
 
 	void generateFailedParsingTextHistory(Long userId, String parsingText);
+
+	String generateAnonymousSucceedParsingTextHistory(String parsingText);
+
+	String generateAnonymousFailedParsingTextHistory(
+		String parsingText,
+		EnglishLevel englishLevel,
+		KoreanLevel koreanLevel
+	);
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/domain/ParsingRequesterType.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/domain/ParsingRequesterType.java
@@ -1,0 +1,6 @@
+package com.plzgraduate.myongjigraduatebe.parsing.domain;
+
+public enum ParsingRequesterType {
+	MEMBER,
+	ANONYMOUS
+}

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/domain/ParsingTextHistory.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/domain/ParsingTextHistory.java
@@ -13,6 +13,8 @@ public class ParsingTextHistory {
 	private final ParsingResult parsingResult;
 	private final FailureReason failureReason;
 	private final String failureDetails;
+	private final String trackingCode;
+	private final ParsingRequesterType requesterType;
 
 	@Builder
 	private ParsingTextHistory(
@@ -21,7 +23,9 @@ public class ParsingTextHistory {
 		String parsingText,
 		ParsingResult parsingResult,
 		FailureReason failureReason,
-		String failureDetails
+		String failureDetails,
+		String trackingCode,
+		ParsingRequesterType requesterType
 	) {
 		this.id = id;
 		this.user = user;
@@ -29,6 +33,8 @@ public class ParsingTextHistory {
 		this.parsingResult = parsingResult;
 		this.failureReason = failureReason;
 		this.failureDetails = failureDetails;
+		this.trackingCode = trackingCode;
+		this.requesterType = requesterType;
 	}
 
 	public static ParsingTextHistory success(User user, String parsingText) {
@@ -36,6 +42,7 @@ public class ParsingTextHistory {
 			.user(user)
 			.parsingText(parsingText)
 			.parsingResult(ParsingResult.SUCCESS)
+			.requesterType(ParsingRequesterType.MEMBER)
 			.build();
 	}
 
@@ -44,6 +51,7 @@ public class ParsingTextHistory {
 			.user(user)
 			.parsingText(parsingText)
 			.parsingResult(ParsingResult.FAIL)
+			.requesterType(ParsingRequesterType.MEMBER)
 			.build();
 	}
 
@@ -54,6 +62,32 @@ public class ParsingTextHistory {
 			.parsingResult(ParsingResult.FAIL)
 			.failureReason(failureReason)
 			.failureDetails(failureDetails)
+			.requesterType(ParsingRequesterType.MEMBER)
+			.build();
+	}
+
+	public static ParsingTextHistory anonymousSuccess(String parsingText, String trackingCode) {
+		return ParsingTextHistory.builder()
+			.parsingText(parsingText)
+			.parsingResult(ParsingResult.SUCCESS)
+			.trackingCode(trackingCode)
+			.requesterType(ParsingRequesterType.ANONYMOUS)
+			.build();
+	}
+
+	public static ParsingTextHistory anonymousFail(
+		String parsingText,
+		FailureReason failureReason,
+		String failureDetails,
+		String trackingCode
+	) {
+		return ParsingTextHistory.builder()
+			.parsingText(parsingText)
+			.parsingResult(ParsingResult.FAIL)
+			.failureReason(failureReason)
+			.failureDetails(failureDetails)
+			.trackingCode(trackingCode)
+			.requesterType(ParsingRequesterType.ANONYMOUS)
 			.build();
 	}
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/infrastructure/adapter/persistence/entity/ParsingTextHistoryJpaEntity.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/infrastructure/adapter/persistence/entity/ParsingTextHistoryJpaEntity.java
@@ -3,9 +3,11 @@ package com.plzgraduate.myongjigraduatebe.parsing.infrastructure.adapter.persist
 import com.plzgraduate.myongjigraduatebe.core.entity.TimeBaseEntity;
 import com.plzgraduate.myongjigraduatebe.parsing.domain.FailureReason;
 import com.plzgraduate.myongjigraduatebe.parsing.domain.ParsingResult;
+import com.plzgraduate.myongjigraduatebe.parsing.domain.ParsingRequesterType;
 import com.plzgraduate.myongjigraduatebe.user.infrastructure.adapter.persistence.entity.UserJpaEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -37,4 +39,12 @@ public class ParsingTextHistoryJpaEntity extends TimeBaseEntity {
 
 	@Column(columnDefinition = "TEXT")
 	private String failureDetails;
+
+	@Column(length = 36, unique = true)
+	private String trackingCode;
+
+	@Enumerated(EnumType.STRING)
+	@Column(length = 20, nullable = false)
+	@Builder.Default
+	private ParsingRequesterType requesterType = ParsingRequesterType.MEMBER;
 }

--- a/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/infrastructure/adapter/persistence/mapper/ParsingTextHistoryMapper.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/parsing/infrastructure/adapter/persistence/mapper/ParsingTextHistoryMapper.java
@@ -1,6 +1,7 @@
 package com.plzgraduate.myongjigraduatebe.parsing.infrastructure.adapter.persistence.mapper;
 
 import com.plzgraduate.myongjigraduatebe.parsing.domain.ParsingTextHistory;
+import com.plzgraduate.myongjigraduatebe.parsing.domain.ParsingRequesterType;
 import com.plzgraduate.myongjigraduatebe.parsing.infrastructure.adapter.persistence.entity.ParsingTextHistoryJpaEntity;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.ExchangeCredit;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.TransferCredit;
@@ -20,6 +21,10 @@ public class ParsingTextHistoryMapper {
 			.parsingResult(parsingTextHistory.getParsingResult())
 			.failureReason(parsingTextHistory.getFailureReason())
 			.failureDetails(parsingTextHistory.getFailureDetails())
+			.trackingCode(parsingTextHistory.getTrackingCode())
+			.requesterType(parsingTextHistory.getRequesterType() == null
+				? ParsingRequesterType.MEMBER
+				: parsingTextHistory.getRequesterType())
 			.build();
 	}
 
@@ -31,10 +36,15 @@ public class ParsingTextHistoryMapper {
 			.parsingResult(parsingTextHistoryJpaEntity.getParsingResult())
 			.failureReason(parsingTextHistoryJpaEntity.getFailureReason())
 			.failureDetails(parsingTextHistoryJpaEntity.getFailureDetails())
+			.trackingCode(parsingTextHistoryJpaEntity.getTrackingCode())
+			.requesterType(parsingTextHistoryJpaEntity.getRequesterType())
 			.build();
 	}
 
 	public UserJpaEntity mapToUserJpaEntity(User user) {
+		if (user == null) {
+			return null;
+		}
 
 		return UserJpaEntity.builder()
 			.id(user.getId())
@@ -53,6 +63,9 @@ public class ParsingTextHistoryMapper {
 	}
 
 	private User mapToUserDomainEntity(UserJpaEntity user) {
+		if (user == null) {
+			return null;
+		}
 		return User.builder()
 			.id(user.getId())
 			.authId(user.getAuthId())

--- a/src/main/resources/db/migration/V8__track_anonymous_parsing_requests.sql
+++ b/src/main/resources/db/migration/V8__track_anonymous_parsing_requests.sql
@@ -1,0 +1,9 @@
+ALTER TABLE parsing_text_history
+	ADD COLUMN tracking_code VARCHAR(36) NULL COMMENT '비회원 검사 문의용 추적 코드',
+	ADD COLUMN requester_type VARCHAR(20) NOT NULL DEFAULT 'MEMBER' COMMENT '회원/비회원 요청 구분';
+
+CREATE UNIQUE INDEX uk_parsing_text_history_tracking_code
+	ON parsing_text_history (tracking_code);
+
+CREATE INDEX idx_parsing_text_history_requester_result_created
+	ON parsing_text_history (requester_type, parsing_result, created_at);

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/api/CheckGraduationRequirementControllerTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/api/CheckGraduationRequirementControllerTest.java
@@ -11,6 +11,7 @@ import com.plzgraduate.myongjigraduatebe.graduation.api.dto.request.CheckGraduat
 import com.plzgraduate.myongjigraduatebe.graduation.application.usecase.CheckGraduationRequirementUseCase;
 import com.plzgraduate.myongjigraduatebe.graduation.domain.model.GraduationResult;
 import com.plzgraduate.myongjigraduatebe.parsing.application.usecase.ParsingAnonymousUseCase;
+import com.plzgraduate.myongjigraduatebe.parsing.application.usecase.ParsingTextHistoryUseCase;
 import com.plzgraduate.myongjigraduatebe.parsing.application.usecase.dto.ParsingAnonymousDto;
 import com.plzgraduate.myongjigraduatebe.takenlecture.domain.model.TakenLectureInventory;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.EnglishLevel;
@@ -43,6 +44,9 @@ class CheckGraduationRequirementControllerTest {
 
 	@MockBean
 	private CheckGraduationRequirementUseCase checkGraduationRequirementUseCase;
+
+	@MockBean
+	private ParsingTextHistoryUseCase parsingTextHistoryUseCase;
 
 	@DisplayName("비회원 졸업진단 응답의 user 정보는 계산된 졸업 결과를 반영한다.")
 	@Test
@@ -79,6 +83,8 @@ class CheckGraduationRequirementControllerTest {
 			.willReturn(parsingAnonymousDto);
 		given(checkGraduationRequirementUseCase.checkGraduationRequirement(any(User.class), any(TakenLectureInventory.class)))
 			.willReturn(graduationResult);
+		given(parsingTextHistoryUseCase.generateAnonymousSucceedParsingTextHistory("mock parsing text"))
+			.willReturn("tracking-code");
 
 		mockMvc.perform(
 				post("/api/v1/graduations/check")
@@ -89,6 +95,36 @@ class CheckGraduationRequirementControllerTest {
 			.andExpect(jsonPath("$.user.studentNumber").value("60190872"))
 			.andExpect(jsonPath("$.user.totalCredit").value(128))
 			.andExpect(jsonPath("$.user.takenCredit").value(133))
-			.andExpect(jsonPath("$.user.graduated").value(true));
+			.andExpect(jsonPath("$.user.graduated").value(true))
+			.andExpect(jsonPath("$.trackingCode").value("tracking-code"));
+	}
+
+	@DisplayName("비회원 졸업진단 실패 응답에 문의용 추적 코드를 포함한다.")
+	@Test
+	void checkGraduationRequirementReturnsTrackingCodeOnFailure() throws Exception {
+		CheckGraduationRequirementRequest request = CheckGraduationRequirementRequest.builder()
+			.engLv("ENG34")
+			.korLv("FREE")
+			.parsingText("invalid parsing text")
+			.build();
+		given(parsingAnonymousUseCase.parseAnonymous(
+			EnglishLevel.ENG34,
+			KoreanLevel.FREE,
+			"invalid parsing text"
+		)).willThrow(new IllegalArgumentException("PARSING_FAILED"));
+		given(parsingTextHistoryUseCase.generateAnonymousFailedParsingTextHistory(
+			"invalid parsing text",
+			EnglishLevel.ENG34,
+			KoreanLevel.FREE
+		)).willReturn("failure-tracking-code");
+
+		mockMvc.perform(
+				post("/api/v1/graduations/check")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(request))
+			)
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.errorCode").value("PARSING_FAILED"))
+			.andExpect(jsonPath("$.trackingCode").value("failure-tracking-code"));
 	}
 }

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/parsing/application/service/ParsingTextHistoryServiceTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/parsing/application/service/ParsingTextHistoryServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.BDDMockito.then;
 import com.plzgraduate.myongjigraduatebe.parsing.application.port.SaveParsingTextHistoryPort;
 import com.plzgraduate.myongjigraduatebe.parsing.domain.FailureReason;
 import com.plzgraduate.myongjigraduatebe.parsing.domain.ParsingTextHistory;
+import com.plzgraduate.myongjigraduatebe.parsing.domain.ParsingRequesterType;
 import com.plzgraduate.myongjigraduatebe.user.application.usecase.find.FindUserUseCase;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.EnglishLevel;
 import com.plzgraduate.myongjigraduatebe.user.domain.model.KoreanLevel;
@@ -85,6 +86,50 @@ class ParsingTextHistoryServiceTest {
 		assertThat(captureArgument.getParsingText()).isEqualTo(parsingText);
 		assertThat(captureArgument.getFailureReason()).isEqualTo(failureReason);
 		assertThat(captureArgument.getFailureDetails()).isEqualTo(failureDetails);
+	}
+
+	@DisplayName("비회원 성공 이력은 사용자 없이 추적 코드와 함께 저장한다.")
+	@Test
+	void generateAnonymousSucceedParsingTextHistory() {
+		ArgumentCaptor<ParsingTextHistory> captor = ArgumentCaptor.forClass(ParsingTextHistory.class);
+
+		String trackingCode = parsingTextHistoryService
+			.generateAnonymousSucceedParsingTextHistory("anonymous text");
+
+		then(saveParsingTextHistoryPort).should().saveParsingTextHistory(captor.capture());
+		assertThat(trackingCode).isNotBlank();
+		assertThat(captor.getValue().getUser()).isNull();
+		assertThat(captor.getValue().getTrackingCode()).isEqualTo(trackingCode);
+		assertThat(captor.getValue().getRequesterType()).isEqualTo(ParsingRequesterType.ANONYMOUS);
+	}
+
+	@DisplayName("비회원 실패 이력은 분석 결과와 추적 코드를 함께 저장한다.")
+	@Test
+	void generateAnonymousFailedParsingTextHistory() {
+		FailureAnalysisService.FailureAnalysisResult analysisResult =
+			new FailureAnalysisService.FailureAnalysisResult(
+				FailureReason.PARSING_EXCEPTION,
+				"파싱 실패"
+			);
+		given(failureAnalysisService.analyzeFailure(
+			"invalid text",
+			EnglishLevel.ENG12,
+			KoreanLevel.KOR12
+		)).willReturn(analysisResult);
+		ArgumentCaptor<ParsingTextHistory> captor = ArgumentCaptor.forClass(ParsingTextHistory.class);
+
+		String trackingCode = parsingTextHistoryService.generateAnonymousFailedParsingTextHistory(
+			"invalid text",
+			EnglishLevel.ENG12,
+			KoreanLevel.KOR12
+		);
+
+		then(saveParsingTextHistoryPort).should().saveParsingTextHistory(captor.capture());
+		assertThat(trackingCode).isNotBlank();
+		assertThat(captor.getValue().getUser()).isNull();
+		assertThat(captor.getValue().getFailureReason()).isEqualTo(FailureReason.PARSING_EXCEPTION);
+		assertThat(captor.getValue().getTrackingCode()).isEqualTo(trackingCode);
+		assertThat(captor.getValue().getRequesterType()).isEqualTo(ParsingRequesterType.ANONYMOUS);
 	}
 
 	private User createUser(Long id, String authId, String password, EnglishLevel englishLevel,


### PR DESCRIPTION
## 작업 내용

- 비회원 졸업검사 성공·실패 요청을 모두 `parsing_text_history`에 저장합니다.
- 비회원 이력은 `requester_type = ANONYMOUS`, `user_id = NULL`로 구분합니다.
- 요청마다 UUID `tracking_code`를 발급하고 성공·실패 API 응답에 포함합니다.
- 실패 이력에는 기존 분석 로직을 재사용해 `failure_reason`, `failure_details`를 기록합니다.
- 이력 저장 실패가 본래 졸업검사 응답을 가리지 않도록 별도 트랜잭션과 예외 격리를 적용했습니다.
- Flyway V8 마이그레이션과 테이블 문서를 추가했습니다.

## 작업 배경

기존에는 비회원 졸업검사 요청이 저장되지 않아 이용 건수와 성공률을 집계하기 어렵고, 오류 문의가 들어와도 해당 요청을 식별할 수 없었습니다. 성공·실패 모두 저장해 운영 지표를 확인하고, 실패 응답의 추적번호로 문의 건을 조회할 수 있게 합니다.

## 사용자 및 운영 영향

- 비회원 성공 응답에 `trackingCode`가 추가됩니다.
- 비회원 실패 응답에 `trackingCode`가 추가됩니다.
- 운영 DB에서는 애플리케이션 시작 시 Flyway V8이 자동 적용됩니다.
- `(requester_type, parsing_result, created_at)` 인덱스로 비회원 이용량과 성공률을 조회할 수 있습니다.

## 검증

- `./gradlew test` 전체 통과
- 관련 컨트롤러·서비스·영속성 테스트 통과
- `git diff --check` 통과
- 로컬 MySQL에 V8 적용 후 실제 실패 요청의 응답 `trackingCode`와 DB 저장값 일치 확인