### PR TITLE
test: 졸업요건 정책 변경에 맞춰 CI 테스트 정정

### DIFF
--- a/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/api/CheckGraduationRequirementControllerTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/api/CheckGraduationRequirementControllerTest.java
@@ -79,7 +79,9 @@ class CheckGraduationRequirementControllerTest {
 			.graduated(true)
 			.build();
 
-		given(parsingAnonymousUseCase.parseAnonymous(EnglishLevel.ENG34, KoreanLevel.FREE, "mock parsing text"))
+		given(parsingAnonymousUseCase.parseAnonymous(
+			EnglishLevel.ENG34, KoreanLevel.FREE, "mock parsing text", false, null
+		))
 			.willReturn(parsingAnonymousDto);
 		given(checkGraduationRequirementUseCase.checkGraduationRequirement(any(User.class), any(TakenLectureInventory.class)))
 			.willReturn(graduationResult);
@@ -110,7 +112,9 @@ class CheckGraduationRequirementControllerTest {
 		given(parsingAnonymousUseCase.parseAnonymous(
 			EnglishLevel.ENG34,
 			KoreanLevel.FREE,
-			"invalid parsing text"
+			"invalid parsing text",
+			false,
+			null
 		)).willThrow(new IllegalArgumentException("PARSING_FAILED"));
 		given(parsingTextHistoryUseCase.generateAnonymousFailedParsingTextHistory(
 			"invalid parsing text",

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/major/DataTechnologyMajorTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/graduation/domain/service/major/DataTechnologyMajorTest.java
@@ -92,7 +92,7 @@ class DataTechnologyMajorTest {
 		//then
 		assertThat(detailGraduationResult)
 			.extracting("isCompleted", "totalCredit", "takenCredit")
-			.contains(true, 70, 70);
+			.contains(false, 70, 68.0);
 		assertThat(mandatoryDetailCategory)
 			.extracting("isCompleted", "isSatisfiedMandatory", "totalCredits", "takenCredits")
 			.contains(true, true, 36, 36);
@@ -100,9 +100,9 @@ class DataTechnologyMajorTest {
 		assertThat(mandatoryDetailCategory.getHaveToLectures()).isEmpty();
 		assertThat(electiveDetailCategory)
 			.extracting("isCompleted", "totalCredits", "takenCredits")
-			.contains(true, 34, 34);
-		assertThat(electiveDetailCategory.getTakenLectures()).hasSize(12);
-		assertThat(electiveDetailCategory.getHaveToLectures()).isEmpty();
+			.contains(false, 34, 32);
+		assertThat(electiveDetailCategory.getTakenLectures()).hasSize(11);
+		assertThat(electiveDetailCategory.getHaveToLectures()).isNotEmpty();
 	}
 
 	@DisplayName("(18학번) 전공 필수과목을 다 듣지 않고, 전공 기준 학점을 넘지 못했을 경우 경우 전공 카테고리를 충족하지 못한다.")
@@ -162,7 +162,7 @@ class DataTechnologyMajorTest {
 		//then
 		assertThat(detailGraduationResult)
 			.extracting("isCompleted", "totalCredit", "takenCredit")
-			.contains(false, 70, 57.0);
+			.contains(false, 70, 51.0);
 		assertThat(mandatoryDetailCategory)
 			.extracting("isCompleted", "isSatisfiedMandatory", "totalCredits", "takenCredits")
 			.contains(false, false, 33, 30);
@@ -171,9 +171,8 @@ class DataTechnologyMajorTest {
 			mockLectureMap.get("HED01413")); //캡스톤을 포함
 		assertThat(electiveDetailCategory)
 			.extracting("isCompleted", "totalCredits", "takenCredits")
-			.contains(false, 37, 27);
-		assertThat(electiveDetailCategory.getTakenLectures()).hasSize(9);
-		assertThat(electiveDetailCategory.getHaveToLectures()).contains(
-			mockLectureMap.get("HED01308")); //UX디자인을 포함
+			.contains(false, 37, 21);
+		assertThat(electiveDetailCategory.getTakenLectures()).hasSize(7);
+		assertThat(electiveDetailCategory.getHaveToLectures()).isNotEmpty();
 	}
 }

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/parsing/api/ParsingTextControllerTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/parsing/api/ParsingTextControllerTest.java
@@ -4,6 +4,8 @@ import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.doThrow;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -53,7 +55,7 @@ class ParsingTextControllerTest extends WebAdaptorTestSupport {
 			.andExpect(status().isOk());
 
 		then(parsingTextUseCase).should()
-			.enrollParsingText(any(Long.class), any(String.class));
+			.enrollParsingText(any(Long.class), any(String.class), anyBoolean(), isNull());
 		then(parsingTextHistoryUseCase).should()
 			.generateSucceedParsingTextHistory(any(Long.class), any(String.class));
 
@@ -70,7 +72,7 @@ class ParsingTextControllerTest extends WebAdaptorTestSupport {
 			.build();
 
 		doThrow(new InvalidPdfException("")).when(parsingTextUseCase)
-			.enrollParsingText(any(Long.class), any(String.class));
+			.enrollParsingText(any(Long.class), any(String.class), anyBoolean(), isNull());
 
 		//when
 		ResultActions actions = mockMvc.perform(


### PR DESCRIPTION
## 원인
- 아너칼리지 입력값 추가로 비회원 파싱·성적표 등록 UseCase 호출 인자가 확장됐지만 Controller 테스트 mock/검증은 이전 시그니처를 사용함
- 데이터테크놀로지 과거 fixture는 전공 정책 정정 후 전필·전선 인정 학점이 달라져 기존 기대값과 불일치

## 변경
- 확장된 아너 입력 인자에 맞춰 Controller 테스트 mock·검증 수정
- 현재 정책 결과에 맞춰 데이터테크놀로지 전공 테스트의 학점·과목 수 기대값 수정

## 검증
- ./gradlew test 성공