### PR TITLE
fix: 학문기초 구 정책 중복 조회 방지

### DIFF
--- a/src/main/java/com/plzgraduate/myongjigraduatebe/lecture/infrastructure/adapter/persistence/repository/BasicAcademicalCultureRepository.java
+++ b/src/main/java/com/plzgraduate/myongjigraduatebe/lecture/infrastructure/adapter/persistence/repository/BasicAcademicalCultureRepository.java
@@ -13,7 +13,14 @@ public interface BasicAcademicalCultureRepository extends
 
 	@Query("select bac from BasicAcademicalCultureLectureJpaEntity bac " +
 		"join fetch bac.lectureJpaEntity where " +
-		"(bac.major = :major or (bac.major is null and bac.college = :college and (" +
+		"(bac.major = :major or (bac.major is null and bac.college = :college " +
+			"and not exists (" +
+				"select scoped.id from BasicAcademicalCultureLectureJpaEntity scoped " +
+				"where scoped.lectureJpaEntity.id = bac.lectureJpaEntity.id " +
+				"and scoped.major = :major " +
+				"and (scoped.startEntryYear is null or scoped.startEntryYear <= :entryYear) " +
+				"and (scoped.endEntryYear is null or scoped.endEntryYear >= :entryYear)" +
+			") and (" +
 			"bac.mappingKey is not null or not exists (" +
 				"select managed.id from BasicAcademicalCultureLectureJpaEntity managed " +
 				"where managed.mappingKey is not null " +

--- a/src/test/java/com/plzgraduate/myongjigraduatebe/lecture/infrastructure/adapter/persistence/repository/BasicAcademicalCultureLectureRepositoryTest.java
+++ b/src/test/java/com/plzgraduate/myongjigraduatebe/lecture/infrastructure/adapter/persistence/repository/BasicAcademicalCultureLectureRepositoryTest.java
@@ -96,6 +96,38 @@ class BasicAcademicalCultureLectureRepositoryTest extends PersistenceTestSupport
 			.containsExactlyInAnyOrder("COMMON", "SCOPED");
 	}
 
+	@DisplayName("같은 과목의 전공 정책이 있으면 무범위 단과대 구 행을 제외한다.")
+	@Test
+	void excludeLegacyCollegePolicyWhenMajorPolicyExistsForSameLecture() {
+		LectureJpaEntity lecture = lectureRepository.save(LectureJpaEntity.builder()
+			.id("DUPLICATE_POLICY")
+			.build());
+
+		basicAcademicalCultureRepository.saveAll(List.of(
+			BasicAcademicalCultureLectureJpaEntity.builder()
+				.lectureJpaEntity(lecture)
+				.college(ICT.getName())
+				.build(),
+			BasicAcademicalCultureLectureJpaEntity.builder()
+				.lectureJpaEntity(lecture)
+				.college(ICT.getName())
+				.major("응용소프트웨어전공")
+				.startEntryYear(18)
+				.endEntryYear(24)
+				.mappingKey("application-software-policy")
+				.build()
+		));
+
+		List<BasicAcademicalCultureLectureJpaEntity> result =
+			basicAcademicalCultureRepository.findAllApplicable(
+				ICT.getName(), "응용소프트웨어전공", 20);
+
+		assertThat(result).singleElement()
+			.extracting(policy -> policy.getLectureJpaEntity().getId(),
+				BasicAcademicalCultureLectureJpaEntity::getMajor)
+			.containsExactly("DUPLICATE_POLICY", "응용소프트웨어전공");
+	}
+
 	@DisplayName("전공 정책은 현재 단과대명이 학번 기반 fallback과 달라도 조회한다.")
 	@Test
 	void findMajorPolicyRegardlessOfFallbackCollege() {


### PR DESCRIPTION
## Issue

- DEV-111

## ✅ 작업 내용

- 동일 강의의 전공별 학문기초 정책이 있으면 무기한 구 단과대 fallback 행을 제외하도록 조회 조건을 보완했습니다.
- 수강시점이 종료된 전공별 정책이 구 행 때문에 현재 미이수 추천에 다시 나타나는 문제를 방지했습니다.
- 동일 강의의 전공 정책과 구 단과대 행이 함께 있을 때 전공 정책만 반환하는 회귀 테스트를 추가했습니다.

## 🤔 고민 했던 부분

- 정책 행의 수강시점 종료 조건 자체는 기존 계산기가 올바르게 처리하고 있었습니다. 문제는 그 전에 같은 강의의 무기한 구 행이 함께 조회되는 것이어서, 데이터 삭제 대신 전공 정책 우선 조회로 해결했습니다.

## 🔊 도움이 필요한 부분!!

- 없음