### PR TITLE
[DEV-112] 개발서버(dev) PostgreSQL(Neon) 전환

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,9 @@ dependencies {
     // MySQL 드라이버 (새 좌표)
     runtimeOnly 'com.mysql:mysql-connector-j:8.4.0'
 
+    // PostgreSQL 드라이버 (Render + Neon dev 서버용)
+    runtimeOnly 'org.postgresql:postgresql'
+
     // Flyway (DB 마이그레이션)
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-mysql'

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -73,7 +73,7 @@ spring:
       on-profile: dev
 
   datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
+    driver-class-name: org.postgresql.Driver
     url: ${DATASOURCE_URL}
     username: ${DATASOURCE_USERNAME}
     password: ${DATASOURCE_PASSWORD}
@@ -81,6 +81,10 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
+    properties:
+      hibernate:
+        # "user" 등 Postgres 예약어를 테이블/컬럼명으로 쓸 때 자동으로 quoting 처리
+        auto_quote_keyword: true
 
   flyway:
     enabled: false


### PR DESCRIPTION
## Issue
- DEV-112

## ✅ 작업 내용
- AWS 프리티어 만료로 개발서버(dev)를 EC2+RDS(MySQL)에서 Render+Neon(PostgreSQL)로 이전하기 위한 코드 변경
- `build.gradle`: PostgreSQL 드라이버(`org.postgresql:postgresql`) 런타임 의존성 추가
- `application.yml`(dev 프로필): datasource 드라이버를 `com.mysql.cj.jdbc.Driver` → `org.postgresql.Driver`로 변경
- `hibernate.auto_quote_keyword: true` 추가

## 🤔 고민 했던 부분
- `user` 테이블명이 PostgreSQL 예약어라서 `ddl-auto: update`가 테이블 생성에 실패하는 이슈가 있었습니다.
- 엔티티의 테이블명을 `users`로 바꾸는 방법도 있었지만, 코드 변경 범위를 넓히고 싶지 않아서 Hibernate의 `auto_quote_keyword` 옵션으로 예약어를 자동 quoting 처리하는 쪽을 선택했습니다.